### PR TITLE
PR13 的后半部分

### DIFF
--- a/components/ProblemCatetory/index.tsx
+++ b/components/ProblemCatetory/index.tsx
@@ -123,13 +123,14 @@ function ProblemCategoryList({
           data.child.map((item) => (
             <li className="d-flex justify-content-between">
               <a
-                href={"https://leetcode.com/problems" + item.src}
+                href={"https://leetcode.cn/problems" + item.src}
                 target="_blank"
               >
                 {item.title}
               </a>
-              {item.score && (
+              {item.score ? (
                 <div className="ms-2 text-nowrap d-flex justify-content-center align-items-center pb-rating-bg">
+                  <a href={"https://leetcode.com/problems" + item.src} target="_blank"> 🇺🇸 </a>
                   <RatingCircle difficulty={Number(item.score)} />
                   <ColorRating
                     className="rating-text"
@@ -138,6 +139,8 @@ function ProblemCategoryList({
                     {Number(item.score).toFixed(0)}
                   </ColorRating>
                 </div>
+              ) : (
+                <a href={"https://leetcode.com/problems" + item.src } target="_blank"> 🇺🇸 </a>
               )}
             </li>
           ))}


### PR DESCRIPTION
上一个PR https://github.com/huxulm/lc-rating/pull/13 加上了了zen tab 下面的指向leetcode.com 的emoji
但是因为 我还把ds tab 下面（专项训练）的超链接直接指向了leetcode.com 
这个交互跟zen tab 上的并不一致
而且我相信大部分人也不希望这样改，毕竟大部分人还是用的leetcode cn

这个PR 相当于把专项训练的超链接改回了指向leetcode cn
然后跟在zen tab 下面的差不多，在超链接的右侧加上了emoji 指向了leetcode.com



效果如连接
https://wnykuang.github.io/lc-rating/list/ds