### PR TITLE
加了灵神的新题单

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ yarn-error.log*
 lc-maker/.venv
 lc-maker/__pycache__
 lc-maker/hds.txt
+
+.venv

--- a/app/(lc)/list/bit/page.tsx
+++ b/app/(lc)/list/bit/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { lazy } from "react";
+
+const List = lazy(() => import("@components/containers/List/BitManipulation"));
+
+export default function Page() {
+  return <List />;
+}

--- a/app/(lc)/list/bs/page.tsx
+++ b/app/(lc)/list/bs/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { lazy } from "react";
+
+const List = lazy(() => import("@components/containers/List/BinarySearch"));
+
+export default function Page() {
+  return <List />;
+}

--- a/app/(lc)/list/graph/page.tsx
+++ b/app/(lc)/list/graph/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { lazy } from "react";
+
+const List = lazy(() => import("@components/containers/List/Graph"));
+
+export default function Page() {
+  return <List />;
+}

--- a/app/(lc)/list/greedy/page.tsx
+++ b/app/(lc)/list/greedy/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { lazy } from "react";
+
+const List = lazy(() => import("@components/containers/List/Greedy"));
+
+export default function Page() {
+  return <List />;
+}

--- a/app/(lc)/list/grid/page.tsx
+++ b/app/(lc)/list/grid/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { lazy } from "react";
+
+const List = lazy(() => import("@components/containers/List/Grid"));
+
+export default function Page() {
+  return <List />;
+} 

--- a/app/(lc)/list/ms/page.tsx
+++ b/app/(lc)/list/ms/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { lazy } from "react";
+
+const List = lazy(() => import("@components/containers/List/MonotonicStack"));
+
+export default function Page() {
+  return <List />;
+} 

--- a/app/(lc)/list/sw/page.tsx
+++ b/app/(lc)/list/sw/page.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { lazy } from "react";
+
+const List = lazy(() => import("@components/containers/List/SlideWindow"));
+
+export default function Page() {
+  return <List />;
+}

--- a/components/ProblemCatetory/index.tsx
+++ b/components/ProblemCatetory/index.tsx
@@ -13,6 +13,7 @@ type ProblemCategory = {
   solution?: string;
   score?: Number;
   child?: ProblemCategory[];
+  isPremium?: boolean;
 };
 
 interface ProblemCategoryProps {

--- a/components/ProblemCatetory/index.tsx
+++ b/components/ProblemCatetory/index.tsx
@@ -140,7 +140,7 @@ function ProblemCategoryList({
                 href={"https://leetcode.cn/problems" + item.src}
                 target="_blank"
               >
-                {item.title}
+                {item.title + (item.isPremium ? " (会员题)" : "")}
                 {en && <a className="ms-2" href={"https://leetcode.com/problems" + item.src} target="_blank">
                   <ShareIcon height={16} width={16}/>
                 </a>}

--- a/components/containers/List/BinarySearch/index.tsx
+++ b/components/containers/List/BinarySearch/index.tsx
@@ -1,0 +1,93 @@
+"use client";
+import Container from "react-bootstrap/Container";
+import ProblemCategory, { hashCode } from "@components/ProblemCatetory";
+import {
+  TableOfContent,
+  TOC,
+} from "@components/ProblemCatetory/TableOfContent";
+import Data from "@components/containers/List/data/binarysearch";
+import { useEffect, useState } from "react";
+import Form from "react-bootstrap/esm/Form";
+
+const mapCategory2TOC = (
+  { title, child, isLeaf }: ProblemCategory,
+  level: number
+): TOC => {
+  let toc = {
+    id: `#${hashCode(title)}`,
+    title: title,
+    level: level,
+    count: 0,
+  } as TOC;
+  // console.log(toc.title, toc.id);
+  if (child && !isLeaf) {
+    toc.children = child.map((c) => mapCategory2TOC(c, level + 1));
+    toc.children.forEach((t) => {
+      toc.count += t.count;
+    });
+  }
+  if (isLeaf) {
+    toc.count = child.length;
+  }
+  return toc;
+};
+
+export default function () {
+  const scrollToComponent = () => {
+    if (window.location.hash) {
+      let id = window.location.hash.replace("#", "");
+      const ele = document.getElementById(id);
+      if (ele) {
+        ele.scrollIntoView({ behavior: "instant" });
+        ele.focus();
+      }
+    }
+  };
+
+  useEffect(() => scrollToComponent(), []);
+  const [showEn, setShowEn] = useState<boolean>(true);
+  const [showRating, setShowRating] = useState<boolean>(true);
+  return (
+    <Container fluid className="p-2 problem-list order-1">
+      <div className="toc" id="toc">
+        <TableOfContent toc={mapCategory2TOC(Data, 0)} />
+      </div>
+      <div
+        className="pb-content ms-5 p-2"
+        data-bs-spy="scroll"
+        data-bs-target="#toc"
+      >
+        <Form
+          className="position-absolute d-flex justify-content-end gap-3 fw-bold"
+          style={{ top: "80px", right: "10px" }}
+        >
+          <Form.Check
+            checked={showEn}
+            onChange={() => {
+              setShowEn(!showEn);
+            }}
+            type="switch"
+            label="英文链接"
+            id="toggle-tags"
+          />
+          <Form.Check
+            checked={showRating}
+            onChange={() => {
+              setShowRating(!showRating);
+            }}
+            type="switch"
+            label="难度分"
+            id="toggle-ratings"
+          />
+        </Form>
+        <ProblemCategory
+          title={`<p class="fs-6 fw-bold fst-italic">来源:<a target="_blank" class="ms-2 fs-6 link" href="${Data.original_src}">${Data.original_src}</a> <span class="ms-3 fw-semibold fst-italic">最近更新: ${Data["last_update"]}</span></p>`}
+          data={[Data]}
+          en={showEn}
+          rating={showRating}
+          summary={Data.summary}
+        />
+      </div>
+    </Container>
+  );
+}

--- a/components/containers/List/BitManipulation/index.tsx
+++ b/components/containers/List/BitManipulation/index.tsx
@@ -1,0 +1,93 @@
+"use client";
+import Container from "react-bootstrap/Container";
+import ProblemCategory, { hashCode } from "@components/ProblemCatetory";
+import {
+  TableOfContent,
+  TOC,
+} from "@components/ProblemCatetory/TableOfContent";
+import Data from "@components/containers/List/data/bitmanipulation";
+import { useEffect, useState } from "react";
+import Form from "react-bootstrap/esm/Form";
+
+const mapCategory2TOC = (
+  { title, child, isLeaf }: ProblemCategory,
+  level: number
+): TOC => {
+  let toc = {
+    id: `#${hashCode(title)}`,
+    title: title,
+    level: level,
+    count: 0,
+  } as TOC;
+  // console.log(toc.title, toc.id);
+  if (child && !isLeaf) {
+    toc.children = child.map((c) => mapCategory2TOC(c, level + 1));
+    toc.children.forEach((t) => {
+      toc.count += t.count;
+    });
+  }
+  if (isLeaf) {
+    toc.count = child ? child.length : 0;
+  }
+  return toc;
+};
+
+export default function () {
+  const scrollToComponent = () => {
+    if (window.location.hash) {
+      let id = window.location.hash.replace("#", "");
+      const ele = document.getElementById(id);
+      if (ele) {
+        ele.scrollIntoView({ behavior: "instant" });
+        ele.focus();
+      }
+    }
+  };
+
+  useEffect(() => scrollToComponent(), []);
+  const [showEn, setShowEn] = useState<boolean>(true);
+  const [showRating, setShowRating] = useState<boolean>(true);
+  return (
+    <Container fluid className="p-2 problem-list order-1">
+      <div className="toc" id="toc">
+        <TableOfContent toc={mapCategory2TOC(Data, 0)} />
+      </div>
+      <div
+        className="pb-content ms-5 p-2"
+        data-bs-spy="scroll"
+        data-bs-target="#toc"
+      >
+        <Form
+          className="position-absolute d-flex justify-content-end gap-3 fw-bold"
+          style={{ top: "80px", right: '10px' }}
+        >
+          <Form.Check
+            checked={showEn}
+            onChange={() => {
+              setShowEn(!showEn);
+            }}
+            type="switch"
+            label="英文链接"
+            id="toggle-tags"
+          />
+          <Form.Check
+            checked={showRating}
+            onChange={() => {
+              setShowRating(!showRating);
+            }}
+            type="switch"
+            label="难度分"
+            id="toggle-ratings"
+          />
+        </Form>
+        <ProblemCategory
+          title={`<p class="fs-6 fw-bold fst-italic">来源:<a target="_blank" class="ms-2 fs-6 link" href="${Data.original_src}">${Data.original_src}</a> <span class="ms-3 fw-semibold fst-italic">最近更新: ${Data["last_update"]}</span></p>`}
+          data={[Data]}
+          en={showEn}
+          rating={showRating}
+          summary={Data.summary}
+        />
+      </div>
+    </Container>
+  );
+}

--- a/components/containers/List/Graph/index.tsx
+++ b/components/containers/List/Graph/index.tsx
@@ -1,0 +1,93 @@
+"use client";
+import Container from "react-bootstrap/Container";
+import ProblemCategory, { hashCode } from "@components/ProblemCatetory";
+import {
+  TableOfContent,
+  TOC,
+} from "@components/ProblemCatetory/TableOfContent";
+import Data from "@components/containers/List/data/graph";
+import { useEffect, useState } from "react";
+import Form from "react-bootstrap/esm/Form";
+
+const mapCategory2TOC = (
+  { title, child, isLeaf }: ProblemCategory,
+  level: number
+): TOC => {
+  let toc = {
+    id: `#${hashCode(title)}`,
+    title: title,
+    level: level,
+    count: 0,
+  } as TOC;
+  // console.log(toc.title, toc.id);
+  if (child && !isLeaf) {
+    toc.children = child.map((c) => mapCategory2TOC(c, level + 1));
+    toc.children.forEach((t) => {
+      toc.count += t.count;
+    });
+  }
+  if (isLeaf) {
+    toc.count = child.length;
+  }
+  return toc;
+};
+
+export default function () {
+  const scrollToComponent = () => {
+    if (window.location.hash) {
+      let id = window.location.hash.replace("#", "");
+      const ele = document.getElementById(id);
+      if (ele) {
+        ele.scrollIntoView({ behavior: "instant" });
+        ele.focus();
+      }
+    }
+  };
+
+  useEffect(() => scrollToComponent(), []);
+  const [showEn, setShowEn] = useState<boolean>(true);
+  const [showRating, setShowRating] = useState<boolean>(true);
+  return (
+    <Container fluid className="p-2 problem-list order-1">
+      <div className="toc" id="toc">
+        <TableOfContent toc={mapCategory2TOC(Data, 0)} />
+      </div>
+      <div
+        className="pb-content ms-5 p-2"
+        data-bs-spy="scroll"
+        data-bs-target="#toc"
+      >
+        <Form
+          className="position-absolute d-flex justify-content-end gap-3 fw-bold"
+          style={{ top: "80px", right: "10px" }}
+        >
+          <Form.Check
+            checked={showEn}
+            onChange={() => {
+              setShowEn(!showEn);
+            }}
+            type="switch"
+            label="英文链接"
+            id="toggle-tags"
+          />
+          <Form.Check
+            checked={showRating}
+            onChange={() => {
+              setShowRating(!showRating);
+            }}
+            type="switch"
+            label="难度分"
+            id="toggle-ratings"
+          />
+        </Form>
+        <ProblemCategory
+          title={`<p class="fs-6 fw-bold fst-italic">来源:<a target="_blank" class="ms-2 fs-6 link" href="${Data.original_src}">${Data.original_src}</a> <span class="ms-3 fw-semibold fst-italic">最近更新: ${Data["last_update"]}</span></p>`}
+          data={[Data]}
+          en={showEn}
+          rating={showRating}
+          summary={Data.summary}
+        />
+      </div>
+    </Container>
+  );
+}

--- a/components/containers/List/Greedy/index.tsx
+++ b/components/containers/List/Greedy/index.tsx
@@ -1,0 +1,93 @@
+"use client";
+import Container from "react-bootstrap/Container";
+import ProblemCategory, { hashCode } from "@components/ProblemCatetory";
+import {
+  TableOfContent,
+  TOC,
+} from "@components/ProblemCatetory/TableOfContent";
+import Data from "@components/containers/List/data/greedy";
+import { useEffect, useState } from "react";
+import Form from "react-bootstrap/esm/Form";
+
+const mapCategory2TOC = (
+  { title, child, isLeaf }: ProblemCategory,
+  level: number
+): TOC => {
+  let toc = {
+    id: `#${hashCode(title)}`,
+    title: title,
+    level: level,
+    count: 0,
+  } as TOC;
+  // console.log(toc.title, toc.id);
+  if (child && !isLeaf) {
+    toc.children = child.map((c) => mapCategory2TOC(c, level + 1));
+    toc.children.forEach((t) => {
+      toc.count += t.count;
+    });
+  }
+  if (isLeaf) {
+    toc.count = child.length;
+  }
+  return toc;
+};
+
+export default function () {
+  const scrollToComponent = () => {
+    if (window.location.hash) {
+      let id = window.location.hash.replace("#", "");
+      const ele = document.getElementById(id);
+      if (ele) {
+        ele.scrollIntoView({ behavior: "instant" });
+        ele.focus();
+      }
+    }
+  };
+
+  useEffect(() => scrollToComponent(), []);
+  const [showEn, setShowEn] = useState<boolean>(true);
+  const [showRating, setShowRating] = useState<boolean>(true);
+  return (
+    <Container fluid className="p-2 problem-list order-1">
+      <div className="toc" id="toc">
+        <TableOfContent toc={mapCategory2TOC(Data, 0)} />
+      </div>
+      <div
+        className="pb-content ms-5 p-2"
+        data-bs-spy="scroll"
+        data-bs-target="#toc"
+      >
+        <Form
+          className="position-absolute d-flex justify-content-end gap-3 fw-bold"
+          style={{ top: "80px", right: "10px" }}
+        >
+          <Form.Check
+            checked={showEn}
+            onChange={() => {
+              setShowEn(!showEn);
+            }}
+            type="switch"
+            label="英文链接"
+            id="toggle-tags"
+          />
+          <Form.Check
+            checked={showRating}
+            onChange={() => {
+              setShowRating(!showRating);
+            }}
+            type="switch"
+            label="难度分"
+            id="toggle-ratings"
+          />
+        </Form>
+        <ProblemCategory
+          title={`<p class="fs-6 fw-bold fst-italic">来源:<a target="_blank" class="ms-2 fs-6 link" href="${Data.original_src}">${Data.original_src}</a> <span class="ms-3 fw-semibold fst-italic">最近更新: ${Data["last_update"]}</span></p>`}
+          data={[Data]}
+          en={showEn}
+          rating={showRating}
+          summary={Data.summary}
+        />
+      </div>
+    </Container>
+  );
+}

--- a/components/containers/List/Grid/index.tsx
+++ b/components/containers/List/Grid/index.tsx
@@ -1,0 +1,93 @@
+"use client";
+import Container from "react-bootstrap/Container";
+import ProblemCategory, { hashCode } from "@components/ProblemCatetory";
+import {
+  TableOfContent,
+  TOC,
+} from "@components/ProblemCatetory/TableOfContent";
+import Data from "@components/containers/List/data/grid";
+import { useEffect, useState } from "react";
+import Form from "react-bootstrap/esm/Form";
+
+const mapCategory2TOC = (
+  { title, child, isLeaf }: ProblemCategory,
+  level: number
+): TOC => {
+  let toc = {
+    id: `#${hashCode(title)}`,
+    title: title,
+    level: level,
+    count: 0,
+  } as TOC;
+  // console.log(toc.title, toc.id);
+  if (child && !isLeaf) {
+    toc.children = child.map((c) => mapCategory2TOC(c, level + 1));
+    toc.children.forEach((t) => {
+      toc.count += t.count;
+    });
+  }
+  if (isLeaf) {
+    toc.count = child ? child.length : 0;
+  }
+  return toc;
+};
+
+export default function () {
+  const scrollToComponent = () => {
+    if (window.location.hash) {
+      let id = window.location.hash.replace("#", "");
+      const ele = document.getElementById(id);
+      if (ele) {
+        ele.scrollIntoView({ behavior: "instant" });
+        ele.focus();
+      }
+    }
+  };
+
+  useEffect(() => scrollToComponent(), []);
+  const [showEn, setShowEn] = useState<boolean>(true);
+  const [showRating, setShowRating] = useState<boolean>(true);
+  return (
+    <Container fluid className="p-2 problem-list order-1">
+      <div className="toc" id="toc">
+        <TableOfContent toc={mapCategory2TOC(Data, 0)} />
+      </div>
+      <div
+        className="pb-content ms-5 p-2"
+        data-bs-spy="scroll"
+        data-bs-target="#toc"
+      >
+        <Form
+          className="position-absolute d-flex justify-content-end gap-3 fw-bold"
+          style={{ top: "80px", right: '10px' }}
+        >
+          <Form.Check
+            checked={showEn}
+            onChange={() => {
+              setShowEn(!showEn);
+            }}
+            type="switch"
+            label="英文链接"
+            id="toggle-tags"
+          />
+          <Form.Check
+            checked={showRating}
+            onChange={() => {
+              setShowRating(!showRating);
+            }}
+            type="switch"
+            label="难度分"
+            id="toggle-ratings"
+          />
+        </Form>
+        <ProblemCategory
+          title={`<p class="fs-6 fw-bold fst-italic">来源:<a target="_blank" class="ms-2 fs-6 link" href="${Data.original_src}">${Data.original_src}</a> <span class="ms-3 fw-semibold fst-italic">最近更新: ${Data["last_update"]}</span></p>`}
+          data={[Data]}
+          en={showEn}
+          rating={showRating}
+          summary={Data.summary}
+        />
+      </div>
+    </Container>
+  );
+}

--- a/components/containers/List/MonotonicStack/index.tsx
+++ b/components/containers/List/MonotonicStack/index.tsx
@@ -1,0 +1,93 @@
+"use client";
+import Container from "react-bootstrap/Container";
+import ProblemCategory, { hashCode } from "@components/ProblemCatetory";
+import {
+  TableOfContent,
+  TOC,
+} from "@components/ProblemCatetory/TableOfContent";
+import Data from "@components/containers/List/data/monotonicstack";
+import { useEffect, useState } from "react";
+import Form from "react-bootstrap/esm/Form";
+
+const mapCategory2TOC = (
+  { title, child, isLeaf }: ProblemCategory,
+  level: number
+): TOC => {
+  let toc = {
+    id: `#${hashCode(title)}`,
+    title: title,
+    level: level,
+    count: 0,
+  } as TOC;
+  // console.log(toc.title, toc.id);
+  if (child && !isLeaf) {
+    toc.children = child.map((c) => mapCategory2TOC(c, level + 1));
+    toc.children.forEach((t) => {
+      toc.count += t.count;
+    });
+  }
+  if (isLeaf) {
+    toc.count = child ? child.length : 0;
+  }
+  return toc;
+};
+
+export default function () {
+  const scrollToComponent = () => {
+    if (window.location.hash) {
+      let id = window.location.hash.replace("#", "");
+      const ele = document.getElementById(id);
+      if (ele) {
+        ele.scrollIntoView({ behavior: "instant" });
+        ele.focus();
+      }
+    }
+  };
+
+  useEffect(() => scrollToComponent(), []);
+  const [showEn, setShowEn] = useState<boolean>(true);
+  const [showRating, setShowRating] = useState<boolean>(true);
+  return (
+    <Container fluid className="p-2 problem-list order-1">
+      <div className="toc" id="toc">
+        <TableOfContent toc={mapCategory2TOC(Data, 0)} />
+      </div>
+      <div
+        className="pb-content ms-5 p-2"
+        data-bs-spy="scroll"
+        data-bs-target="#toc"
+      >
+        <Form
+          className="position-absolute d-flex justify-content-end gap-3 fw-bold"
+          style={{ top: "80px", right: '10px' }}
+        >
+          <Form.Check
+            checked={showEn}
+            onChange={() => {
+              setShowEn(!showEn);
+            }}
+            type="switch"
+            label="英文链接"
+            id="toggle-tags"
+          />
+          <Form.Check
+            checked={showRating}
+            onChange={() => {
+              setShowRating(!showRating);
+            }}
+            type="switch"
+            label="难度分"
+            id="toggle-ratings"
+          />
+        </Form>
+        <ProblemCategory
+          title={`<p class="fs-6 fw-bold fst-italic">来源:<a target="_blank" class="ms-2 fs-6 link" href="${Data.original_src}">${Data.original_src}</a> <span class="ms-3 fw-semibold fst-italic">最近更新: ${Data["last_update"]}</span></p>`}
+          data={[Data]}
+          en={showEn}
+          rating={showRating}
+          summary={Data.summary}
+        />
+      </div>
+    </Container>
+  );
+}

--- a/components/containers/List/SlideWindow/index.tsx
+++ b/components/containers/List/SlideWindow/index.tsx
@@ -1,0 +1,93 @@
+"use client";
+import Container from "react-bootstrap/Container";
+import ProblemCategory, { hashCode } from "@components/ProblemCatetory";
+import {
+  TableOfContent,
+  TOC,
+} from "@components/ProblemCatetory/TableOfContent";
+import Data from "@components/containers/List/data/slidewindow";
+import { useEffect, useState } from "react";
+import Form from "react-bootstrap/esm/Form";
+
+const mapCategory2TOC = (
+  { title, child, isLeaf }: ProblemCategory,
+  level: number
+): TOC => {
+  let toc = {
+    id: `#${hashCode(title)}`,
+    title: title,
+    level: level,
+    count: 0,
+  } as TOC;
+  // console.log(toc.title, toc.id);
+  if (child && !isLeaf) {
+    toc.children = child.map((c) => mapCategory2TOC(c, level + 1));
+    toc.children.forEach((t) => {
+      toc.count += t.count;
+    });
+  }
+  if (isLeaf) {
+    toc.count = child ? child.length : 0;
+  }
+  return toc;
+};
+
+export default function () {
+  const scrollToComponent = () => {
+    if (window.location.hash) {
+      let id = window.location.hash.replace("#", "");
+      const ele = document.getElementById(id);
+      if (ele) {
+        ele.scrollIntoView({ behavior: "instant" });
+        ele.focus();
+      }
+    }
+  };
+
+  useEffect(() => scrollToComponent(), []);
+  const [showEn, setShowEn] = useState<boolean>(true);
+  const [showRating, setShowRating] = useState<boolean>(true);
+  return (
+    <Container fluid className="p-2 problem-list order-1">
+      <div className="toc" id="toc">
+        <TableOfContent toc={mapCategory2TOC(Data, 0)} />
+      </div>
+      <div
+        className="pb-content ms-5 p-2"
+        data-bs-spy="scroll"
+        data-bs-target="#toc"
+      >
+        <Form
+          className="position-absolute d-flex justify-content-end gap-3 fw-bold"
+          style={{ top: "80px", right: '10px' }}
+        >
+          <Form.Check
+            checked={showEn}
+            onChange={() => {
+              setShowEn(!showEn);
+            }}
+            type="switch"
+            label="英文链接"
+            id="toggle-tags"
+          />
+          <Form.Check
+            checked={showRating}
+            onChange={() => {
+              setShowRating(!showRating);
+            }}
+            type="switch"
+            label="难度分"
+            id="toggle-ratings"
+          />
+        </Form>
+        <ProblemCategory
+          title={`<p class="fs-6 fw-bold fst-italic">来源:<a target="_blank" class="ms-2 fs-6 link" href="${Data.original_src}">${Data.original_src}</a> <span class="ms-3 fw-semibold fst-italic">最近更新: ${Data["last_update"]}</span></p>`}
+          data={[Data]}
+          en={showEn}
+          rating={showRating}
+          summary={Data.summary}
+        />
+      </div>
+    </Container>
+  );
+}

--- a/components/containers/List/data/binarysearch.ts
+++ b/components/containers/List/data/binarysearch.ts
@@ -1,0 +1,962 @@
+import ProblemCategory from "@components/ProblemCatetory";
+
+export default{
+    "title": "分享丨【题单】二分算法（二分答案/最小化最大值/最大化最小值/第K小）",
+    "original_src": "https://leetcode.cn/circle/discuss/SqopEo",
+    "last_update": "2024-06-20T11:19:33.330361+00:00",
+    "sort": 0,
+    "child": [
+        {
+            "title": "二分查找",
+            "sort": 0,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br>请先学习：<a href=\"https://www.bilibili.com/video/BV1AP41137w7/\">二分查找 红蓝染色法【基础算法精讲 04】</a><br><br><br>",
+                    "child": [
+                        {
+                            "title": "34. 在排序数组中查找元素的第一个和最后一个位置",
+                            "sort": 0,
+                            "src": "/find-first-and-last-position-of-element-in-sorted-array/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "35. 搜索插入位置",
+                            "sort": 1,
+                            "src": "/search-insert-position/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "704. 二分查找",
+                            "sort": 2,
+                            "src": "/binary-search/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "744. 寻找比目标字母大的最小字母",
+                            "sort": 3,
+                            "src": "/find-smallest-letter-greater-than-target/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2529. 正整数和负整数的最大计数",
+                            "sort": 4,
+                            "src": "/maximum-count-of-positive-integer-and-negative-integer/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1385. 两个数组间的距离值",
+                            "sort": 5,
+                            "src": "/find-the-distance-value-between-two-arrays/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2300. 咒语和药水的成功对数",
+                            "sort": 6,
+                            "src": "/successful-pairs-of-spells-and-potions/",
+                            "score": 1477,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2389. 和有限的最长子序列",
+                            "sort": 7,
+                            "src": "/longest-subsequence-with-limited-sum/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1170. 比较字符串最小字母出现频次",
+                            "sort": 8,
+                            "src": "/compare-strings-by-frequency-of-the-smallest-character/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2080. 区间内查询数字的频率",
+                            "sort": 9,
+                            "src": "/range-frequency-queries/",
+                            "score": 1702,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2563. 统计公平数对的数目",
+                            "sort": 10,
+                            "src": "/count-the-number-of-fair-pairs/",
+                            "score": 1721,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2856. 删除数对后的最小数组长度",
+                            "sort": 11,
+                            "src": "/minimum-array-length-after-pair-removals/",
+                            "score": 1750,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "981. 基于时间的键值存储",
+                            "sort": 12,
+                            "src": "/time-based-key-value-store/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1146. 快照数组",
+                            "sort": 13,
+                            "src": "/snapshot-array/",
+                            "score": 1771,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1818. 绝对差值和",
+                            "sort": 14,
+                            "src": "/minimum-absolute-sum-difference/",
+                            "score": 1934,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "911. 在线选举",
+                            "sort": 15,
+                            "src": "/online-election/",
+                            "score": 2001,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCP 08. 剧情触发时间",
+                            "sort": 16,
+                            "src": "/ju-qing-hong-fa-shi-jian/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1150. 检查一个数是否在数组中占绝大多数",
+                            "sort": 17,
+                            "src": "/check-if-a-number-is-majority-element-in-a-sorted-array/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1064. 不动点",
+                            "sort": 18,
+                            "src": "/fixed-point/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "702. 搜索长度未知的有序数组",
+                            "sort": 19,
+                            "src": "/search-in-a-sorted-array-of-unknown-size/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1182. 与目标颜色间的最短距离",
+                            "sort": 20,
+                            "src": "/shortest-distance-to-target-color/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2819. 购买巧克力后的最小相对损失",
+                            "sort": 21,
+                            "src": "/minimum-relative-loss-after-buying-chocolates/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2936. 包含相等值数字块的数量",
+                            "sort": 22,
+                            "src": "/number-of-equal-numbers-blocks/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "二分答案：求最小",
+            "sort": 1,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><br>",
+                    "child": [
+                        {
+                            "title": "1283. 使结果不超过阈值的最小除数",
+                            "sort": 0,
+                            "src": "/find-the-smallest-divisor-given-a-threshold/",
+                            "score": 1542,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2187. 完成旅途的最少时间",
+                            "sort": 1,
+                            "src": "/minimum-time-to-complete-trips/",
+                            "score": 1641,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1870. 准时到达的列车最小时速",
+                            "sort": 2,
+                            "src": "/minimum-speed-to-arrive-on-time/",
+                            "score": 1676,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1011. 在 D 天内送达包裹的能力",
+                            "sort": 3,
+                            "src": "/capacity-to-ship-packages-within-d-days/",
+                            "score": 1725,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "875. 爱吃香蕉的珂珂",
+                            "sort": 4,
+                            "src": "/koko-eating-bananas/",
+                            "score": 1766,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "475. 供暖器",
+                            "sort": 5,
+                            "src": "/heaters/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2594. 修车的最少时间",
+                            "sort": 6,
+                            "src": "/minimum-time-to-repair-cars/",
+                            "score": 1915,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1482. 制作 m 束花所需的最少天数",
+                            "sort": 7,
+                            "src": "/minimum-number-of-days-to-make-m-bouquets/",
+                            "score": 1946,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3048. 标记所有下标的最早秒数 I",
+                            "sort": 8,
+                            "src": "/earliest-second-to-mark-indices-i/",
+                            "score": 2263,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3049. 标记所有下标的最早秒数 II",
+                            "sort": 9,
+                            "src": "/earliest-second-to-mark-indices-ii/",
+                            "score": 3111,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2604. 吃掉所有谷子的最短时间",
+                            "sort": 10,
+                            "src": "/minimum-time-to-eat-all-grains/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2702. 使数字变为非正数的最小操作次数",
+                            "sort": 11,
+                            "src": "/minimum-operations-to-make-numbers-non-positive/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "二分答案：求最大",
+            "sort": 2,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><a href=\"https://leetcode.cn/problems/h-index-ii/solution/tu-jie-yi-tu-zhang-wo-er-fen-da-an-si-ch-d15k/\">一图掌握二分答案！四种写法！</a><br><br>在练习时，请注意「求最小」和「求最大」的二分写法上的区别。<br><br>前面的「求最小」和二分查找求「排序数组中某元素的第一个位置」是类似的，按照红蓝染色法，左边是不满足要求的（红色），右边则是满足要求的（蓝色）。<br><br>「求最大」的题目则相反，左边是满足要求的（蓝色），右边是不满足要求的（红色）。这会导致二分写法和上面的「求最小」有一些区别。<br><br>以开区间二分为例：<br><br>- 求最小：`check(mid) == true` 时更新 `right = mid`，反之更新 `left = mid`，最后返回 `right`。<br>- 求最大：`check(mid) == true` 时更新 `left = mid`，反之更新 `right = mid`，最后返回 `left`。<br><br>对于开区间写法，简单来说 `check(mid) == true` 时更新的是谁，最后就返回谁。相比其他二分写法，开区间写法不需要思考加一减一等细节，个人推荐使用开区间写二分。<br><br><br>",
+                    "child": [
+                        {
+                            "title": "275. H 指数 II",
+                            "sort": 0,
+                            "src": "/h-index-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2226. 每个小孩最多能分到多少糖果",
+                            "sort": 1,
+                            "src": "/maximum-candies-allocated-to-k-children/",
+                            "score": 1646,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2982. 找出出现至少三次的最长特殊子字符串 II",
+                            "sort": 2,
+                            "src": "/find-longest-special-substring-that-occurs-thrice-ii/",
+                            "score": 1773,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2576. 求出最多标记下标",
+                            "sort": 3,
+                            "src": "/find-the-maximum-number-of-marked-indices/",
+                            "score": 1843,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1898. 可移除字符的最大数目",
+                            "sort": 4,
+                            "src": "/maximum-number-of-removable-characters/",
+                            "score": 1913,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1802. 有界数组中指定下标处的最大值",
+                            "sort": 5,
+                            "src": "/maximum-value-at-a-given-index-in-a-bounded-array/",
+                            "score": 1929,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1642. 可以到达的最远建筑",
+                            "sort": 6,
+                            "src": "/furthest-building-you-can-reach/",
+                            "score": 1962,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2861. 最大合金数",
+                            "sort": 7,
+                            "src": "/maximum-number-of-alloys/",
+                            "score": 1981,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3007. 价值和小于等于 K 的最大数字",
+                            "sort": 8,
+                            "src": "/maximum-number-that-sum-of-the-prices-is-less-than-or-equal-to-k/",
+                            "score": 2258,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2141. 同时运行 N 台电脑的最长时间",
+                            "sort": 9,
+                            "src": "/maximum-running-time-of-n-computers/",
+                            "score": 2265,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2258. 逃离火灾",
+                            "sort": 10,
+                            "src": "/escape-the-spreading-fire/",
+                            "score": 2347,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2071. 你可以安排的最多任务数目",
+                            "sort": 11,
+                            "src": "/maximum-number-of-tasks-you-can-assign/",
+                            "score": 2648,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1618. 找出适应屏幕的最大字号",
+                            "sort": 12,
+                            "src": "/maximum-font-to-fit-a-sentence-in-a-screen/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1891. 割绳子",
+                            "sort": 13,
+                            "src": "/cutting-ribbons/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2137. 通过倒水操作让所有的水桶所含水量相等",
+                            "sort": 14,
+                            "src": "/pour-water-between-buckets-to-make-water-levels-equal/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "644. 子数组最大平均数 II",
+                            "sort": 15,
+                            "src": "/maximum-average-subarray-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "二分间接值",
+            "sort": 3,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br>二分的不是答案，而是一个和答案有关的值（间接值）。<br><br><br>",
+                    "child": [
+                        {
+                            "title": "3143. 正方形中的最多点数",
+                            "sort": 0,
+                            "src": "/maximum-points-inside-the-square/",
+                            "score": 1697,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1648. 销售价值减少的颜色球",
+                            "sort": 1,
+                            "src": "/sell-diminishing-valued-colored-balls/",
+                            "score": 2050,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "最小化最大值",
+            "sort": 4,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br>本质是二分答案求最小。<br><br><br>",
+                    "child": [
+                        {
+                            "title": "410. 分割数组的最大值",
+                            "sort": 0,
+                            "src": "/split-array-largest-sum/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2064. 分配给商店的最多商品的最小值",
+                            "sort": 1,
+                            "src": "/minimized-maximum-of-products-distributed-to-any-store/",
+                            "score": 1886,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1760. 袋子里最少数目的球",
+                            "sort": 2,
+                            "src": "/minimum-limit-of-balls-in-a-bag/",
+                            "score": 1940,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1631. 最小体力消耗路径",
+                            "sort": 3,
+                            "src": "/path-with-minimum-effort/",
+                            "score": 1948,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2439. 最小化数组中的最大值",
+                            "sort": 4,
+                            "src": "/minimize-maximum-of-array/",
+                            "score": 1965,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2560. 打家劫舍 IV",
+                            "sort": 5,
+                            "src": "/house-robber-iv/",
+                            "score": 2081,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "778. 水位上升的泳池中游泳",
+                            "sort": 6,
+                            "src": "/swim-in-rising-water/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2616. 最小化数对的最大差值",
+                            "sort": 7,
+                            "src": "/minimize-the-maximum-difference-of-pairs/",
+                            "score": 2155,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2513. 最小化两个数组中的最大值",
+                            "sort": 8,
+                            "src": "/minimize-the-maximum-of-two-arrays/",
+                            "score": 2302,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "774. 最小化去加油站的最大距离",
+                            "sort": 9,
+                            "src": "/minimize-max-distance-to-gas-station/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "最大化最小值",
+            "sort": 5,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br>本质是二分答案求最大。<br><br><br>",
+                    "child": [
+                        {
+                            "title": "2517. 礼盒的最大甜蜜度",
+                            "sort": 0,
+                            "src": "/maximum-tastiness-of-candy-basket/",
+                            "score": 2021,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1552. 两球之间的磁力",
+                            "sort": 1,
+                            "src": "/magnetic-force-between-two-balls/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2812. 找出最安全路径",
+                            "sort": 2,
+                            "src": "/find-the-safest-path-in-a-grid/",
+                            "score": 2154,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2528. 最大化城市的最小供电站数目",
+                            "sort": 3,
+                            "src": "/maximize-the-minimum-powered-city/",
+                            "score": 2236,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCP 12. 小张刷题计划",
+                            "sort": 4,
+                            "src": "/xiao-zhang-shua-ti-ji-hua/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1102. 得分最高的路径",
+                            "sort": 5,
+                            "src": "/path-with-maximum-minimum-value/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1231. 分享巧克力",
+                            "sort": 6,
+                            "src": "/divide-chocolate/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "第 K 小/大",
+            "sort": 6,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br>部分题目也可以用堆解决。<br><br><br>",
+                    "child": [
+                        {
+                            "title": "378. 有序矩阵中第 K 小的元素",
+                            "sort": 0,
+                            "src": "/kth-smallest-element-in-a-sorted-matrix/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "668. 乘法表中第 K 小的数",
+                            "sort": 1,
+                            "src": "/kth-smallest-number-in-multiplication-table/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "373. 查找和最小的 K 对数字",
+                            "sort": 2,
+                            "src": "/find-k-pairs-with-smallest-sums/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "719. 找出第 K 小的数对距离",
+                            "sort": 3,
+                            "src": "/find-k-th-smallest-pair-distance/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "878. 第 N 个神奇数字",
+                            "sort": 4,
+                            "src": "/nth-magical-number/",
+                            "score": 1897,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1201. 丑数 III",
+                            "sort": 5,
+                            "src": "/ugly-number-iii/",
+                            "score": 2039,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "793. 阶乘函数后 K 个零",
+                            "sort": 6,
+                            "src": "/preimage-size-of-factorial-zeroes-function/",
+                            "score": 2100,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1439. 有序矩阵中的第 k 个最小数组和",
+                            "sort": 7,
+                            "src": "/find-the-kth-smallest-sum-of-a-matrix-with-sorted-rows/",
+                            "score": 2134,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "786. 第 K 个最小的素数分数",
+                            "sort": 8,
+                            "src": "/k-th-smallest-prime-fraction/",
+                            "score": 2169,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3116. 单面值组合的第 K 小金额",
+                            "sort": 9,
+                            "src": "/kth-smallest-amount-with-single-denomination-combination/",
+                            "score": 2387,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3134. 找出唯一性数组的中位数",
+                            "sort": 10,
+                            "src": "/find-the-median-of-the-uniqueness-array/",
+                            "score": 2451,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2040. 两个有序数组的第 K 小乘积",
+                            "sort": 11,
+                            "src": "/kth-smallest-product-of-two-sorted-arrays/",
+                            "score": 2518,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2386. 找出数组的第 K 大和",
+                            "sort": 12,
+                            "src": "/find-the-k-sum-of-an-array/",
+                            "score": 2648,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1508. 子数组和排序后的区间和",
+                            "sort": 13,
+                            "src": "/range-sum-of-sorted-subarray-sums/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1918. 第 K 小的子数组和",
+                            "sort": 14,
+                            "src": "/kth-smallest-subarray-sum/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "其他",
+            "sort": 7,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><br>",
+                    "child": [
+                        {
+                            "title": "2476. 二叉搜索树最近节点查询",
+                            "sort": 0,
+                            "src": "/closest-nodes-queries-in-a-binary-search-tree/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "74. 搜索二维矩阵",
+                            "sort": 1,
+                            "src": "/search-a-2d-matrix/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "240. 搜索二维矩阵 II",
+                            "sort": 2,
+                            "src": "/search-a-2d-matrix-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "278. 第一个错误的版本",
+                            "sort": 3,
+                            "src": "/first-bad-version/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "374. 猜数字大小",
+                            "sort": 4,
+                            "src": "/guess-number-higher-or-lower/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "162. 寻找峰值",
+                            "sort": 5,
+                            "src": "/find-peak-element/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1901. 寻找峰值 II",
+                            "sort": 6,
+                            "src": "/find-a-peak-element-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "852. 山脉数组的峰顶索引",
+                            "sort": 7,
+                            "src": "/peak-index-in-a-mountain-array/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1095. 山脉数组中查找目标值",
+                            "sort": 8,
+                            "src": "/find-in-mountain-array/",
+                            "score": 1827,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "153. 寻找旋转排序数组中的最小值",
+                            "sort": 9,
+                            "src": "/find-minimum-in-rotated-sorted-array/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "33. 搜索旋转排序数组",
+                            "sort": 10,
+                            "src": "/search-in-rotated-sorted-array/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1539. 第 k 个缺失的正整数",
+                            "sort": 11,
+                            "src": "/kth-missing-positive-number/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "540. 有序数组中的单一元素",
+                            "sort": 12,
+                            "src": "/single-element-in-a-sorted-array/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "4. 寻找两个正序数组的中位数",
+                            "sort": 13,
+                            "src": "/median-of-two-sorted-arrays/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1060. 有序数组中的缺失元素",
+                            "sort": 14,
+                            "src": "/missing-element-in-sorted-array/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1198. 找出所有行中最小公共元素",
+                            "sort": 15,
+                            "src": "/find-smallest-common-element-in-all-rows/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1428. 至少有一个 1 的最左端列",
+                            "sort": 16,
+                            "src": "/leftmost-column-with-at-least-a-one/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1533. 找到最大整数的索引",
+                            "sort": 17,
+                            "src": "/find-the-index-of-the-large-integer/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2387. 行排序矩阵的中位数",
+                            "sort": 18,
+                            "src": "/median-of-a-row-wise-sorted-matrix/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+} as ProblemCategory;

--- a/components/containers/List/data/binarysearch.ts
+++ b/components/containers/List/data/binarysearch.ts
@@ -15,7 +15,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br>请先学习：<a href=\"https://www.bilibili.com/video/BV1AP41137w7/\">二分查找 红蓝染色法【基础算法精讲 04】</a><br><br><br>",
+                    "summary": "请先学习：<a href=\"https://www.bilibili.com/video/BV1AP41137w7/\">二分查找 红蓝染色法【基础算法精讲 04】</a><br>",
                     "child": [
                         {
                             "title": "34. 在排序数组中查找元素的第一个和最后一个位置",
@@ -214,7 +214,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><br>",
+                    "summary": "",
                     "child": [
                         {
                             "title": "1283. 使结果不超过阈值的最小除数",
@@ -325,7 +325,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><a href=\"https://leetcode.cn/problems/h-index-ii/solution/tu-jie-yi-tu-zhang-wo-er-fen-da-an-si-ch-d15k/\">一图掌握二分答案！四种写法！</a><br><br>在练习时，请注意「求最小」和「求最大」的二分写法上的区别。<br><br>前面的「求最小」和二分查找求「排序数组中某元素的第一个位置」是类似的，按照红蓝染色法，左边是不满足要求的（红色），右边则是满足要求的（蓝色）。<br><br>「求最大」的题目则相反，左边是满足要求的（蓝色），右边是不满足要求的（红色）。这会导致二分写法和上面的「求最小」有一些区别。<br><br>以开区间二分为例：<br><br>- 求最小：`check(mid) == true` 时更新 `right = mid`，反之更新 `left = mid`，最后返回 `right`。<br>- 求最大：`check(mid) == true` 时更新 `left = mid`，反之更新 `right = mid`，最后返回 `left`。<br><br>对于开区间写法，简单来说 `check(mid) == true` 时更新的是谁，最后就返回谁。相比其他二分写法，开区间写法不需要思考加一减一等细节，个人推荐使用开区间写二分。<br><br><br>",
+                    "summary": "<a href=\"https://leetcode.cn/problems/h-index-ii/solution/tu-jie-yi-tu-zhang-wo-er-fen-da-an-si-ch-d15k/\">一图掌握二分答案！四种写法！</a><br>在练习时，请注意「求最小」和「求最大」的二分写法上的区别。<br>前面的「求最小」和二分查找求「排序数组中某元素的第一个位置」是类似的，按照红蓝染色法，左边是不满足要求的（红色），右边则是满足要求的（蓝色）。<br>「求最大」的题目则相反，左边是满足要求的（蓝色），右边是不满足要求的（红色）。这会导致二分写法和上面的「求最小」有一些区别。<br>以开区间二分为例：<br>- 求最小：`check(mid) == true` 时更新 `right = mid`，反之更新 `left = mid`，最后返回 `right`。<br>- 求最大：`check(mid) == true` 时更新 `left = mid`，反之更新 `right = mid`，最后返回 `left`。<br>对于开区间写法，简单来说 `check(mid) == true` 时更新的是谁，最后就返回谁。相比其他二分写法，开区间写法不需要思考加一减一等细节，个人推荐使用开区间写二分。<br>",
                     "child": [
                         {
                             "title": "275. H 指数 II",
@@ -468,7 +468,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br>二分的不是答案，而是一个和答案有关的值（间接值）。<br><br><br>",
+                    "summary": "二分的不是答案，而是一个和答案有关的值（间接值）。<br>",
                     "child": [
                         {
                             "title": "3143. 正方形中的最多点数",
@@ -499,7 +499,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br>本质是二分答案求最小。<br><br><br>",
+                    "summary": "本质是二分答案求最小。<br>",
                     "child": [
                         {
                             "title": "410. 分割数组的最大值",
@@ -553,7 +553,7 @@ export default{
                             "title": "778. 水位上升的泳池中游泳",
                             "sort": 6,
                             "src": "/swim-in-rising-water/",
-                            "score": null,
+                            "score": 2097,
                             "solution": null,
                             "isPremium": false
                         },
@@ -594,7 +594,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br>本质是二分答案求最大。<br><br><br>",
+                    "summary": "本质是二分答案求最大。<br>",
                     "child": [
                         {
                             "title": "2517. 礼盒的最大甜蜜度",
@@ -665,7 +665,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br>部分题目也可以用堆解决。<br><br><br>",
+                    "summary": "部分题目也可以用堆解决。<br>",
                     "child": [
                         {
                             "title": "378. 有序矩阵中第 K 小的元素",
@@ -800,7 +800,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><br>",
+                    "summary": "",
                     "child": [
                         {
                             "title": "2476. 二叉搜索树最近节点查询",

--- a/components/containers/List/data/bitmanipulation.ts
+++ b/components/containers/List/data/bitmanipulation.ts
@@ -1,0 +1,810 @@
+import ProblemCategory from "@components/ProblemCatetory";
+
+export default{
+    "title": "分享丨【题单】位运算（基础/性质/拆位/试填/恒等式/思维）",
+    "original_src": "https://leetcode.cn/circle/discuss/dHn9Vk",
+    "last_update": "2024-07-06T01:38:21.527264+00:00",
+    "sort": 0,
+    "child": [
+        {
+            "title": "一、基础题",
+            "sort": 0,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><br>",
+                    "child": [
+                        {
+                            "title": "1486. 数组异或操作",
+                            "sort": 0,
+                            "src": "/xor-operation-in-an-array/",
+                            "score": 1181,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2595. 奇偶位数",
+                            "sort": 1,
+                            "src": "/number-of-even-and-odd-bits/",
+                            "score": 1207,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "231. 2 的幂",
+                            "sort": 2,
+                            "src": "/power-of-two/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "342. 4 的幂",
+                            "sort": 3,
+                            "src": "/power-of-four/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "476. 数字的补数",
+                            "sort": 4,
+                            "src": "/number-complement/",
+                            "score": 1235,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "191. 位 1 的个数",
+                            "sort": 5,
+                            "src": "/number-of-1-bits/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "338. 比特位计数",
+                            "sort": 6,
+                            "src": "/counting-bits/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1356. 根据数字二进制下 1 的数目排序",
+                            "sort": 7,
+                            "src": "/sort-integers-by-the-number-of-1-bits/",
+                            "score": 1258,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "461. 汉明距离",
+                            "sort": 8,
+                            "src": "/hamming-distance/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2220. 转换数字的最少位翻转次数",
+                            "sort": 9,
+                            "src": "/minimum-bit-flips-to-convert-number/",
+                            "score": 1282,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "868. 二进制间距",
+                            "sort": 10,
+                            "src": "/binary-gap/",
+                            "score": 1307,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2917. 找出数组中的 K-or 值",
+                            "sort": 11,
+                            "src": "/find-the-k-or-of-an-array/",
+                            "score": 1389,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "693. 交替位二进制数",
+                            "sort": 12,
+                            "src": "/binary-number-with-alternating-bits/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "二、与或（AND/OR）的性质",
+            "sort": 1,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br>AND 的数越多，结果越小。OR 的数越多，结果越大。<br><br><br>",
+                    "child": [
+                        {
+                            "title": "2980. 检查按位或是否存在尾随零",
+                            "sort": 0,
+                            "src": "/check-if-bitwise-or-has-trailing-zeros/",
+                            "score": 1234,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1318. 或运算的最小翻转次数",
+                            "sort": 1,
+                            "src": "/minimum-flips-to-make-a-or-b-equal-to-c/",
+                            "score": 1383,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2419. 按位与最大的最长子数组",
+                            "sort": 2,
+                            "src": "/longest-subarray-with-maximum-bitwise-and/",
+                            "score": 1496,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2871. 将数组分割成最多数目的子数组",
+                            "sort": 3,
+                            "src": "/split-array-into-maximum-number-of-subarrays/",
+                            "score": 1750,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2401. 最长优雅子数组",
+                            "sort": 4,
+                            "src": "/longest-nice-subarray/",
+                            "score": 1750,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3097. 或值至少为 K 的最短子数组 II",
+                            "sort": 5,
+                            "src": "/shortest-subarray-with-or-at-least-k-ii/",
+                            "score": 1891,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3133. 数组最后一个元素的最小值",
+                            "sort": 6,
+                            "src": "/minimum-array-end/",
+                            "score": 1935,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2680. 最大或值",
+                            "sort": 7,
+                            "src": "/maximum-or/) 1912 可以做到 $\\mathcal{O}(1",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2411. 按位或最大的最小子数组长度",
+                            "sort": 8,
+                            "src": "/smallest-subarrays-with-maximum-bitwise-or/",
+                            "score": 1938,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3108. 带权图里旅途的最小代价",
+                            "sort": 9,
+                            "src": "/minimum-cost-walk-in-weighted-graph/",
+                            "score": 2109,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "898. 子数组按位或操作",
+                            "sort": 10,
+                            "src": "/bitwise-ors-of-subarrays/",
+                            "score": 2133,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1521. 找到最接近目标值的函数值",
+                            "sort": 11,
+                            "src": "/find-a-value-of-a-mysterious-function-closest-to-target/",
+                            "score": 2384,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3171. 找到按位或最接近 K 的子数组",
+                            "sort": 12,
+                            "src": "/find-subarray-with-bitwise-or-closest-to-k/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3117. 划分数组得到最小的值之和",
+                            "sort": 13,
+                            "src": "/minimum-sum-of-values-by-dividing-array/",
+                            "score": 2735,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3125. 使得按位与结果为 0 的最大数字",
+                            "sort": 14,
+                            "src": "/maximum-number-that-makes-result-of-bitwise-and-zero/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "三、异或（XOR）的性质",
+            "sort": 2,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><br>另见 <a href=\"https://leetcode.cn/circle/discuss/mOr1u6/\">数据结构题单</a> 中的「0-1 字典树（异或字典树）」。<br><br>",
+                    "child": [
+                        {
+                            "title": "1720. 解码异或后的数组",
+                            "sort": 0,
+                            "src": "/decode-xored-array/",
+                            "score": 1284,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2433. 找出前缀异或的原始数组",
+                            "sort": 1,
+                            "src": "/find-the-original-array-of-prefix-xor/",
+                            "score": 1367,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1310. 子数组异或查询",
+                            "sort": 2,
+                            "src": "/xor-queries-of-a-subarray/",
+                            "score": 1460,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2683. 相邻值的按位异或",
+                            "sort": 3,
+                            "src": "/neighboring-bitwise-xor/",
+                            "score": 1518,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1829. 每个查询的最大异或值",
+                            "sort": 4,
+                            "src": "/maximum-xor-for-each-query/",
+                            "score": 1523,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2997. 使数组异或和等于 K 的最少操作次数",
+                            "sort": 5,
+                            "src": "/minimum-number-of-operations-to-make-array-xor-equal-to-k/",
+                            "score": 1525,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1442. 形成两个异或相等数组的三元组数目",
+                            "sort": 6,
+                            "src": "/count-triplets-that-can-form-two-arrays-of-equal-xor/",
+                            "score": 1525,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2429. 最小异或",
+                            "sort": 7,
+                            "src": "/minimize-xor/",
+                            "score": 1532,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2527. 查询数组异或美丽值",
+                            "sort": 8,
+                            "src": "/find-xor-beauty-of-array/",
+                            "score": 1550,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2317. 操作后的最大异或和",
+                            "sort": 9,
+                            "src": "/maximum-xor-after-operations/",
+                            "score": 1679,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2588. 统计美丽子数组数目",
+                            "sort": 10,
+                            "src": "/count-the-number-of-beautiful-subarrays/",
+                            "score": 1697,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2564. 子字符串异或查询",
+                            "sort": 11,
+                            "src": "/substring-xor-queries/",
+                            "score": 1959,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1734. 解码异或后的排列",
+                            "sort": 12,
+                            "src": "/decode-xored-permutation/",
+                            "score": 2024,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2857. 统计距离为 k 的点对",
+                            "sort": 13,
+                            "src": "/count-pairs-of-points-with-distance-k/",
+                            "score": 2082,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1803. 统计异或值在范围内的数对有多少",
+                            "sort": 14,
+                            "src": "/count-pairs-with-xor-in-a-range/",
+                            "score": 2479,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "四、拆位 / 贡献法",
+            "sort": 3,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><br>十进制拆位：<br><br><br>",
+                    "child": [
+                        {
+                            "title": "477. 汉明距离总和",
+                            "sort": 0,
+                            "src": "/total-hamming-distance/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1863. 找出所有子集的异或总和再求和",
+                            "sort": 1,
+                            "src": "/sum-of-all-subset-xor-totals/) 可以做到 $\\mathcal{O}(n",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2425. 所有数对的异或和",
+                            "sort": 2,
+                            "src": "/bitwise-xor-of-all-pairings/) 1622 可以做到 $\\mathcal{O}(n+m",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2275. 按位与结果大于零的最长组合",
+                            "sort": 3,
+                            "src": "/largest-combination-with-bitwise-and-greater-than-zero/",
+                            "score": 1642,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1835. 所有数对按位与结果的异或和",
+                            "sort": 4,
+                            "src": "/find-xor-sum-of-all-pairs-bitwise-and/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2505. 所有子序列和的按位或",
+                            "sort": 5,
+                            "src": "/bitwise-or-of-all-subsequence-sums/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "3153. 所有数对中数位不同之和",
+                            "sort": 6,
+                            "src": "/sum-of-digit-differences-of-all-pairs/",
+                            "score": 1645,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "五、试填法",
+            "sort": 4,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><br>",
+                    "child": [
+                        {
+                            "title": "3007. 价值和小于等于 K 的最大数字",
+                            "sort": 0,
+                            "src": "/maximum-number-that-sum-of-the-prices-is-less-than-or-equal-to-k/",
+                            "score": 2258,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "421. 数组中两个数的最大异或值](https://leetcode.cn/problems/maximum-xor-of-two-numbers-in-an-array/)，[试填法题解",
+                            "sort": 1,
+                            "src": "/maximum-xor-of-two-numbers-in-an-array/solution/tu-jie-jian-ji-gao-xiao-yi-tu-miao-dong-1427d/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2935. 找出强数对的最大异或值 II",
+                            "sort": 2,
+                            "src": "/maximum-strong-pair-xor-ii/",
+                            "score": 2349,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3145. 大数组元素的乘积",
+                            "sort": 3,
+                            "src": "/find-products-of-elements-of-big-array/",
+                            "score": 2859,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3022. 给定操作次数内使剩余元素的或值最小",
+                            "sort": 4,
+                            "src": "/minimize-or-of-remaining-elements-using-operations/",
+                            "score": 2918,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "六、恒等式",
+            "sort": 5,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><br>",
+                    "child": [
+                        {
+                            "title": "1835. 所有数对按位与结果的异或和",
+                            "sort": 0,
+                            "src": "/find-xor-sum-of-all-pairs-bitwise-and/",
+                            "score": 1825,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2354. 优质数对的数目",
+                            "sort": 1,
+                            "src": "/number-of-excellent-pairs/",
+                            "score": 2076,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "七、思维题（贪心、脑筋急转弯等）",
+            "sort": 6,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><br>",
+                    "child": [
+                        {
+                            "title": "2546. 执行逐位运算使字符串相等",
+                            "sort": 0,
+                            "src": "/apply-bitwise-operations-to-make-strings-equal/",
+                            "score": 1605,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1558. 得到目标数组的最少函数调用次数",
+                            "sort": 1,
+                            "src": "/minimum-numbers-of-function-calls-to-make-target-array/",
+                            "score": 1637,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2571. 将整数减少到零需要的最少操作数",
+                            "sort": 2,
+                            "src": "/minimum-operations-to-reduce-an-integer-to-0/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2568. 最小无法得到的或值",
+                            "sort": 3,
+                            "src": "/minimum-impossible-or/",
+                            "score": 1754,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2509. 查询树中环的长度",
+                            "sort": 4,
+                            "src": "/cycle-length-queries-in-a-tree/",
+                            "score": 1948,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2939. 最大异或乘积",
+                            "sort": 5,
+                            "src": "/maximum-xor-product/",
+                            "score": 2128,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2749. 得到整数零需要执行的最少操作数",
+                            "sort": 6,
+                            "src": "/minimum-operations-to-make-the-integer-zero/",
+                            "score": 2132,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2835. 使子序列的和等于目标的最少操作次数",
+                            "sort": 7,
+                            "src": "/minimum-operations-to-form-subsequence-with-target-sum/",
+                            "score": 2207,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2897. 对数组执行操作使平方和最大",
+                            "sort": 8,
+                            "src": "/apply-operations-on-array-to-maximize-sum-of-squares/",
+                            "score": 2301,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "810. 黑板异或游戏",
+                            "sort": 9,
+                            "src": "/chalkboard-xor-game/",
+                            "score": 2341,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "八、其他",
+            "sort": 7,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><br>",
+                    "child": [
+                        {
+                            "title": "136. 只出现一次的数字",
+                            "sort": 0,
+                            "src": "/single-number/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "287. 寻找重复数",
+                            "sort": 1,
+                            "src": "/find-the-duplicate-number/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "260. 只出现一次的数字 III",
+                            "sort": 2,
+                            "src": "/single-number-iii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2965. 找出缺失和重复的数字",
+                            "sort": 3,
+                            "src": "/find-missing-and-repeated-values/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "137. 只出现一次的数字 II",
+                            "sort": 4,
+                            "src": "/single-number-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "645. 错误的集合",
+                            "sort": 5,
+                            "src": "/set-mismatch/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "190. 颠倒二进制位",
+                            "sort": 6,
+                            "src": "/reverse-bits/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "371. 两整数之和",
+                            "sort": 7,
+                            "src": "/sum-of-two-integers/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "201. 数字范围按位与",
+                            "sort": 8,
+                            "src": "/bitwise-and-of-numbers-range/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2154. 将找到的值乘以 2",
+                            "sort": 9,
+                            "src": "/keep-multiplying-found-values-by-two/) 可以做到 $\\mathcal{O}(n",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2044. 统计按位或能得到最大值的子集数目",
+                            "sort": 10,
+                            "src": "/count-number-of-maximum-bitwise-or-subsets/",
+                            "score": 1568,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2438. 二的幂数组中查询范围内的乘积",
+                            "sort": 11,
+                            "src": "/range-product-queries-of-powers/",
+                            "score": 1610,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1680. 连接连续二进制数字",
+                            "sort": 12,
+                            "src": "/concatenation-of-consecutive-binary-numbers/",
+                            "score": 1630,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1261. 在受污染的二叉树中查找元素",
+                            "sort": 13,
+                            "src": "/find-elements-in-a-contaminated-binary-tree/) 做到 $\\mathcal{O}(1",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "89. 格雷编码",
+                            "sort": 14,
+                            "src": "/gray-code/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1238. 循环码排列",
+                            "sort": 15,
+                            "src": "/circular-permutation-in-binary-representation/",
+                            "score": 1775,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "982. 按位与为零的三元组",
+                            "sort": 16,
+                            "src": "/triples-with-bitwise-and-equal-to-zero/",
+                            "score": 2085,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1611. 使整数变为 0 的最少操作次数",
+                            "sort": 17,
+                            "src": "/minimum-one-bit-operations-to-make-integers-zero/",
+                            "score": 2345,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+} as ProblemCategory;

--- a/components/containers/List/data/bitmanipulation.ts
+++ b/components/containers/List/data/bitmanipulation.ts
@@ -15,7 +15,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><br>",
+                    "summary": "",
                     "child": [
                         {
                             "title": "1486. 数组异或操作",
@@ -134,7 +134,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br>AND 的数越多，结果越小。OR 的数越多，结果越大。<br><br><br>",
+                    "summary": "AND 的数越多，结果越小。OR 的数越多，结果越大。<br>",
                     "child": [
                         {
                             "title": "2980. 检查按位或是否存在尾随零",
@@ -195,8 +195,8 @@ export default{
                         {
                             "title": "2680. 最大或值",
                             "sort": 7,
-                            "src": "/maximum-or/) 1912 可以做到 $\\mathcal{O}(1",
-                            "score": null,
+                            "src": "/maximum-or/",
+                            "score": 1912,
                             "solution": null,
                             "isPremium": false
                         },
@@ -236,7 +236,7 @@ export default{
                             "title": "3171. 找到按位或最接近 K 的子数组",
                             "sort": 12,
                             "src": "/find-subarray-with-bitwise-or-closest-to-k/",
-                            "score": null,
+                            "score": 1521,
                             "solution": null,
                             "isPremium": false
                         },
@@ -269,7 +269,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><br>另见 <a href=\"https://leetcode.cn/circle/discuss/mOr1u6/\">数据结构题单</a> 中的「0-1 字典树（异或字典树）」。<br><br>",
+                    "summary": "另见 <a href=\"https://leetcode.cn/circle/discuss/mOr1u6/\">数据结构题单</a> 中的「0-1 字典树（异或字典树）」。<br>",
                     "child": [
                         {
                             "title": "1720. 解码异或后的数组",
@@ -404,7 +404,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><br>十进制拆位：<br><br><br>",
+                    "summary": "十进制拆位：<br>",
                     "child": [
                         {
                             "title": "477. 汉明距离总和",
@@ -417,7 +417,7 @@ export default{
                         {
                             "title": "1863. 找出所有子集的异或总和再求和",
                             "sort": 1,
-                            "src": "/sum-of-all-subset-xor-totals/) 可以做到 $\\mathcal{O}(n",
+                            "src": "/sum-of-all-subset-xor-totals/",
                             "score": null,
                             "solution": null,
                             "isPremium": false
@@ -425,8 +425,8 @@ export default{
                         {
                             "title": "2425. 所有数对的异或和",
                             "sort": 2,
-                            "src": "/bitwise-xor-of-all-pairings/) 1622 可以做到 $\\mathcal{O}(n+m",
-                            "score": null,
+                            "src": "/bitwise-xor-of-all-pairings/",
+                            "score": 1622,
                             "solution": null,
                             "isPremium": false
                         },
@@ -442,7 +442,7 @@ export default{
                             "title": "1835. 所有数对按位与结果的异或和",
                             "sort": 4,
                             "src": "/find-xor-sum-of-all-pairs-bitwise-and/",
-                            "score": null,
+                            "score": 1825,
                             "solution": null,
                             "isPremium": false
                         },
@@ -475,7 +475,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><br>",
+                    "summary": "",
                     "child": [
                         {
                             "title": "3007. 价值和小于等于 K 的最大数字",
@@ -486,11 +486,11 @@ export default{
                             "isPremium": false
                         },
                         {
-                            "title": "421. 数组中两个数的最大异或值](https://leetcode.cn/problems/maximum-xor-of-two-numbers-in-an-array/)，[试填法题解",
+                            "title": "421. 数组中两个数的最大异或值",
                             "sort": 1,
-                            "src": "/maximum-xor-of-two-numbers-in-an-array/solution/tu-jie-jian-ji-gao-xiao-yi-tu-miao-dong-1427d/",
-                            "score": null,
-                            "solution": null,
+                            "src": "/maximum-xor-of-two-numbers-in-an-array/",
+                            "score": 1427,
+                            "solution": "/maximum-xor-of-two-numbers-in-an-array/solution/tu-jie-jian-ji-gao-xiao-yi-tu-miao-dong-1427d/",
                             "isPremium": false
                         },
                         {
@@ -530,7 +530,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><br>",
+                    "summary": "",
                     "child": [
                         {
                             "title": "1835. 所有数对按位与结果的异或和",
@@ -561,7 +561,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><br>",
+                    "summary": "",
                     "child": [
                         {
                             "title": "2546. 执行逐位运算使字符串相等",
@@ -583,7 +583,7 @@ export default{
                             "title": "2571. 将整数减少到零需要的最少操作数",
                             "sort": 2,
                             "src": "/minimum-operations-to-reduce-an-integer-to-0/",
-                            "score": null,
+                            "score": 1649,
                             "solution": null,
                             "isPremium": false
                         },
@@ -656,7 +656,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><br>",
+                    "summary": "",
                     "child": [
                         {
                             "title": "136. 只出现一次的数字",
@@ -733,7 +733,7 @@ export default{
                         {
                             "title": "2154. 将找到的值乘以 2",
                             "sort": 9,
-                            "src": "/keep-multiplying-found-values-by-two/) 可以做到 $\\mathcal{O}(n",
+                            "src": "/keep-multiplying-found-values-by-two/",
                             "score": null,
                             "solution": null,
                             "isPremium": false
@@ -765,8 +765,8 @@ export default{
                         {
                             "title": "1261. 在受污染的二叉树中查找元素",
                             "sort": 13,
-                            "src": "/find-elements-in-a-contaminated-binary-tree/) 做到 $\\mathcal{O}(1",
-                            "score": null,
+                            "src": "/find-elements-in-a-contaminated-binary-tree/",
+                            "score": 1,
                             "solution": null,
                             "isPremium": false
                         },

--- a/components/containers/List/data/graph.ts
+++ b/components/containers/List/data/graph.ts
@@ -1,0 +1,1061 @@
+import ProblemCategory from "@components/ProblemCatetory";
+
+export default{
+    "title": "分享丨【题单】图论算法（DFS/BFS/拓扑排序/最短路/最小生成树/二分图/基环树/欧拉路径）",
+    "original_src": "https://leetcode.cn/circle/discuss/01LUak",
+    "last_update": "2024-03-05T07:11:29.184518+00:00",
+    "sort": 0,
+    "child": [
+        {
+            "title": "DFS 基础",
+            "sort": 0,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "找连通块、判断是否有环等。部分题目做法不止一种。<br>",
+                    "child": [
+                        {
+                            "title": "547. 省份数量",
+                            "sort": 0,
+                            "src": "/number-of-provinces/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1971. 寻找图中是否存在路径",
+                            "sort": 1,
+                            "src": "/find-if-path-exists-in-graph/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "797. 所有可能的路径",
+                            "sort": 2,
+                            "src": "/all-paths-from-source-to-target/",
+                            "score": 1383,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "841. 钥匙和房间",
+                            "sort": 3,
+                            "src": "/keys-and-rooms/",
+                            "score": 1412,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2316. 统计无向图中无法互相到达点对数",
+                            "sort": 4,
+                            "src": "/count-unreachable-pairs-of-nodes-in-an-undirected-graph/",
+                            "score": 1604,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1319. 连通网络的操作次数",
+                            "sort": 5,
+                            "src": "/number-of-operations-to-make-network-connected/",
+                            "score": 1633,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2492. 两个城市间路径的最小分数",
+                            "sort": 6,
+                            "src": "/minimum-score-of-a-path-between-two-cities/",
+                            "score": 1680,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2685. 统计完全连通分量的数量",
+                            "sort": 7,
+                            "src": "/count-the-number-of-complete-components/",
+                            "score": 1769,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2192. 有向无环图中一个节点的所有祖先",
+                            "sort": 8,
+                            "src": "/all-ancestors-of-a-node-in-a-directed-acyclic-graph/",
+                            "score": 1788,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "924. 尽量减少恶意软件的传播",
+                            "sort": 9,
+                            "src": "/minimize-malware-spread/",
+                            "score": 1869,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2101. 引爆最多的炸弹",
+                            "sort": 10,
+                            "src": "/detonate-the-maximum-bombs/",
+                            "score": 1880,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "802. 找到最终的安全状态",
+                            "sort": 11,
+                            "src": "/find-eventual-safe-states/",
+                            "score": 1962,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2092. 找出知晓秘密的所有专家",
+                            "sort": 12,
+                            "src": "/find-all-people-with-secret/",
+                            "score": 2004,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "261. 以图判树",
+                            "sort": 13,
+                            "src": "/graph-valid-tree/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "323. 无向图中连通分量的数目",
+                            "sort": 14,
+                            "src": "/number-of-connected-components-in-an-undirected-graph/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "BFS 基础",
+            "sort": 1,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "求最短路等。<br>",
+                    "child": [
+                        {
+                            "title": "1311. 获取你好友已观看的视频",
+                            "sort": 0,
+                            "src": "/get-watched-videos-by-your-friends/",
+                            "score": 1653,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1129. 颜色交替的最短路径",
+                            "sort": 1,
+                            "src": "/shortest-path-with-alternating-colors/",
+                            "score": 1780,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1298. 你能从盒子里获得的最大糖果数",
+                            "sort": 2,
+                            "src": "/maximum-candies-you-can-get-from-boxes/",
+                            "score": 1825,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2039. 网络空闲的时刻",
+                            "sort": 3,
+                            "src": "/the-time-when-the-network-becomes-idle/",
+                            "score": 1865,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2608. 图中的最短环",
+                            "sort": 4,
+                            "src": "/shortest-cycle-in-a-graph/",
+                            "score": 1904,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "拓扑排序",
+            "sort": 2,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "学习拓扑排序前，请先完成 <a href=\"https://leetcode.cn/problems/minimum-number-of-vertices-to-reach-all-nodes/\">1557. 可以到达所有点的最少点数目</a><br>",
+                    "child": [
+                        {
+                            "title": "207. 课程表",
+                            "sort": 0,
+                            "src": "/course-schedule/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "210. 课程表 II",
+                            "sort": 1,
+                            "src": "/course-schedule-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1462. 课程表 IV",
+                            "sort": 2,
+                            "src": "/course-schedule-iv/",
+                            "score": 1693,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2115. 从给定原材料中找到所有可以做出的菜",
+                            "sort": 3,
+                            "src": "/find-all-possible-recipes-from-given-supplies/",
+                            "score": 1679,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "310. 最小高度树",
+                            "sort": 4,
+                            "src": "/minimum-height-trees/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "802. 找到最终的安全状态",
+                            "sort": 5,
+                            "src": "/find-eventual-safe-states/",
+                            "score": 1962,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1203. 项目管理",
+                            "sort": 6,
+                            "src": "/sort-items-by-groups-respecting-dependencies/",
+                            "score": 2419,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2603. 收集树中金币",
+                            "sort": 7,
+                            "src": "/collect-coins-in-a-tree/",
+                            "score": 2712,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "269. 火星词典",
+                            "sort": 8,
+                            "src": "/alien-dictionary/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "444. 序列重建",
+                            "sort": 9,
+                            "src": "/sequence-reconstruction/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1059. 从始点到终点的所有路径",
+                            "sort": 10,
+                            "src": "/all-paths-from-source-lead-to-destination/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1136. 并行课程",
+                            "sort": 11,
+                            "src": "/parallel-courses/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "在拓扑序上 DP",
+            "sort": 3,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "2050. 并行课程 III",
+                            "sort": 0,
+                            "src": "/parallel-courses-iii/",
+                            "score": 2084,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1857. 有向图中最大颜色值",
+                            "sort": 1,
+                            "src": "/largest-color-value-in-a-directed-graph/",
+                            "score": 2313,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "基环树",
+            "sort": 4,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<a href=\"https://leetcode.cn/problems/maximum-employees-to-be-invited-to-a-meeting/solution/nei-xiang-ji-huan-shu-tuo-bu-pai-xu-fen-c1i1b/\">基环树介绍</a><br>",
+                    "child": [
+                        {
+                            "title": "684. 冗余连接",
+                            "sort": 0,
+                            "src": "/redundant-connection/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2359. 找到离给定两个节点最近的节点",
+                            "sort": 1,
+                            "src": "/find-closest-node-to-given-two-nodes/",
+                            "score": 1715,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2360. 图中的最长环",
+                            "sort": 2,
+                            "src": "/longest-cycle-in-a-graph/",
+                            "score": 1897,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2876. 有向图访问计数",
+                            "sort": 3,
+                            "src": "/count-visited-nodes-in-a-directed-graph/",
+                            "score": 2210,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2127. 参加会议的最多员工数",
+                            "sort": 4,
+                            "src": "/maximum-employees-to-be-invited-to-a-meeting/",
+                            "score": 2449,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2836. 在传球游戏中最大化函数值",
+                            "sort": 5,
+                            "src": "/maximize-value-of-function-in-a-ball-passing-game",
+                            "score": 2769,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2204. 无向图中到环的距离",
+                            "sort": 6,
+                            "src": "/distance-to-a-cycle-in-undirected-graph/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "LCP 21. 追逐游戏",
+                            "sort": 7,
+                            "src": "/Za25hA/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "单源最短路：Dijkstra",
+            "sort": 5,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<a href=\"https://leetcode.cn/problems/network-delay-time/solution/liang-chong-dijkstra-xie-fa-fu-ti-dan-py-ooe8/\">Dijkstra 算法介绍</a><br>",
+                    "child": [
+                        {
+                            "title": "743. 网络延迟时间",
+                            "sort": 0,
+                            "src": "/network-delay-time/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2642. 设计可以求最短路径的图类",
+                            "sort": 1,
+                            "src": "/design-graph-with-shortest-path-calculator/",
+                            "score": 1811,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1514. 概率最大的路径",
+                            "sort": 2,
+                            "src": "/path-with-maximum-probability/",
+                            "score": 1846,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1631. 最小体力消耗路径",
+                            "sort": 3,
+                            "src": "/path-with-minimum-effort/",
+                            "score": 1948,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1368. 使网格图至少有一条有效路径的最小代价",
+                            "sort": 4,
+                            "src": "/minimum-cost-to-make-at-least-one-valid-path-in-a-grid/",
+                            "score": 2069,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1786. 从第一个节点出发到最后一个节点的受限路径数",
+                            "sort": 5,
+                            "src": "/number-of-restricted-paths-from-first-to-last-node/",
+                            "score": 2079,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1976. 到达目的地的方案数",
+                            "sort": 6,
+                            "src": "/number-of-ways-to-arrive-at-destination/",
+                            "score": 2095,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2662. 前往目标的最小代价",
+                            "sort": 7,
+                            "src": "/minimum-cost-of-a-path-with-special-roads/",
+                            "score": 2154,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2045. 到达目的地的第二短时间",
+                            "sort": 8,
+                            "src": "/second-minimum-time-to-reach-destination/",
+                            "score": 2202,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "882. 细分图中的可到达节点",
+                            "sort": 9,
+                            "src": "/reachable-nodes-in-subdivided-graph/",
+                            "score": 2328,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2203. 得到要求路径的最小带权子图",
+                            "sort": 10,
+                            "src": "/minimum-weighted-subgraph-with-the-required-paths/",
+                            "score": 2364,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2577. 在网格图中访问一个格子的最少时间",
+                            "sort": 11,
+                            "src": "/minimum-time-to-visit-a-cell-in-a-grid/",
+                            "score": 2382,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2699. 修改图中的边权",
+                            "sort": 12,
+                            "src": "/modify-graph-edge-weights/",
+                            "score": 2874,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2093. 前往目标城市的最小费用",
+                            "sort": 13,
+                            "src": "/minimum-cost-to-reach-city-with-discounts/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2473. 购买苹果的最低成本",
+                            "sort": 14,
+                            "src": "/minimum-cost-to-buy-apples/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2714. 找到最短路径的 K 次跨越",
+                            "sort": 15,
+                            "src": "/find-shortest-path-with-k-hops/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2737. 找到最近的标记节点",
+                            "sort": 16,
+                            "src": "/find-the-closest-marked-node/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "LCP 35. 电动车游城市",
+                            "sort": 17,
+                            "src": "/DFPeFJ/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCP 56. 信物传送",
+                            "sort": 18,
+                            "src": "/6UEx57/",
+                            "score": 0,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "全源最短路：Floyd",
+            "sort": 6,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<a href=\"https://leetcode.cn/problems/find-the-city-with-the-smallest-number-of-neighbors-at-a-threshold-distance/solution/dai-ni-fa-ming-floyd-suan-fa-cong-ji-yi-m8s51/\">带你发明 Floyd 算法：从记忆化搜索到递推</a><br>",
+                    "child": [
+                        {
+                            "title": "2642. 设计可以求最短路径的图类",
+                            "sort": 0,
+                            "src": "/design-graph-with-shortest-path-calculator/",
+                            "score": 1811,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1334. 阈值距离内邻居最少的城市",
+                            "sort": 1,
+                            "src": "/find-the-city-with-the-smallest-number-of-neighbors-at-a-threshold-distance/",
+                            "score": 1855,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2976. 转换字符串的最小成本 I",
+                            "sort": 2,
+                            "src": "/minimum-cost-to-convert-string-i/",
+                            "score": 1882,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2959. 关闭分部的可行集合数目",
+                            "sort": 3,
+                            "src": "/number-of-possible-sets-of-closing-branches/",
+                            "score": 2077,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2977. 转换字符串的最小成本 II",
+                            "sort": 4,
+                            "src": "/minimum-cost-to-convert-string-ii/",
+                            "score": 2696,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "最小生成树：Kruskal/Prim",
+            "sort": 7,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "1584. 连接所有点的最小费用",
+                            "sort": 0,
+                            "src": "/min-cost-to-connect-all-points/",
+                            "score": 1858,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1489. 找到最小生成树里的关键边和伪关键边",
+                            "sort": 1,
+                            "src": "/find-critical-and-pseudo-critical-edges-in-minimum-spanning-tree/",
+                            "score": 2572,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1135. 最低成本连通所有城市",
+                            "sort": 2,
+                            "src": "/connecting-cities-with-minimum-cost/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1168. 水资源分配优化",
+                            "sort": 3,
+                            "src": "/optimize-water-distribution-in-a-village/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "欧拉路径/欧拉回路：Hierholzer",
+            "sort": 8,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "332. 重新安排行程",
+                            "sort": 0,
+                            "src": "/reconstruct-itinerary/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "753. 破解保险箱",
+                            "sort": 1,
+                            "src": "/cracking-the-safe/",
+                            "score": 2274,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2097. 合法重新排列数对",
+                            "sort": 2,
+                            "src": "/valid-arrangement-of-pairs/",
+                            "score": 2651,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "强连通分量/双连通分量：Tarjan",
+            "sort": 9,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "928. 尽量减少恶意软件的传播 II",
+                            "sort": 0,
+                            "src": "/minimize-malware-spread-ii/",
+                            "score": 1985,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1192. 查找集群内的关键连接",
+                            "sort": 1,
+                            "src": "/critical-connections-in-a-network/",
+                            "score": 2085,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1568. 使陆地分离的最少天数",
+                            "sort": 2,
+                            "src": "/minimum-number-of-days-to-disconnect-island/",
+                            "score": 2209,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCP 54. 夺回据点",
+                            "sort": 3,
+                            "src": "/s5kipK/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "二分图（染色判定、最大匹配）",
+            "sort": 10,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "部分题目做法不止一种。难度仅供参考。<br>",
+                    "child": [
+                        {
+                            "title": "785. 判断二分图",
+                            "sort": 0,
+                            "src": "/is-graph-bipartite/",
+                            "score": 1625,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "886. 可能的二分法",
+                            "sort": 1,
+                            "src": "/possible-bipartition/",
+                            "score": 1795,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1947. 最大兼容性评分和",
+                            "sort": 2,
+                            "src": "/maximum-compatibility-score-sum/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1879. 两个数组最小的异或值之和",
+                            "sort": 3,
+                            "src": "/minimum-xor-sum-of-two-arrays/",
+                            "score": 2145,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1349. 参加考试的最大学生数",
+                            "sort": 4,
+                            "src": "/maximum-students-taking-exam/",
+                            "score": 2386,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2172. 数组的最大与和",
+                            "sort": 5,
+                            "src": "/maximum-and-sum-of-array/",
+                            "score": 2392,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1595. 连通两组点的最小成本",
+                            "sort": 6,
+                            "src": "/minimum-cost-to-connect-two-groups-of-points/",
+                            "score": 2538,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCP 04. 覆盖",
+                            "sort": 7,
+                            "src": "/broken-board-dominoes/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1066. 校园自行车分配 II",
+                            "sort": 8,
+                            "src": "/campus-bikes-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2123. 使矩阵中的 1 互不相邻的最小操作数",
+                            "sort": 9,
+                            "src": "/minimum-operations-to-remove-adjacent-ones-in-matrix/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2403. 杀死所有怪物的最短时间",
+                            "sort": 10,
+                            "src": "/minimum-time-to-kill-all-monsters/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "网络流",
+            "sort": 11,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "做法不止一种。难度仅供参考。<br>",
+                    "child": [
+                        {
+                            "title": "2850. 将石头分散到网格图的最少移动次数",
+                            "sort": 0,
+                            "src": "/minimum-moves-to-spread-stones-over-grid/",
+                            "score": 2001,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1349. 参加考试的最大学生数",
+                            "sort": 1,
+                            "src": "/maximum-students-taking-exam/",
+                            "score": 2386,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2172. 数组的最大与和",
+                            "sort": 2,
+                            "src": "/maximum-and-sum-of-array/",
+                            "score": 2392,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCP 38. 守卫城堡",
+                            "sort": 3,
+                            "src": "/7rLGCR/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "其它",
+            "sort": 12,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "1042. 不邻接植花",
+                            "sort": 0,
+                            "src": "/flower-planting-with-no-adjacent/",
+                            "score": 1712,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "787. K 站中转内最便宜的航班",
+                            "sort": 1,
+                            "src": "/cheapest-flights-within-k-stops/",
+                            "score": 1786,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1761. 一个图中连通三元组的最小度数",
+                            "sort": 2,
+                            "src": "/minimum-degree-of-a-connected-trio-in-a-graph/",
+                            "score": 2005,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2508. 添加边使所有节点度数都为偶数",
+                            "sort": 3,
+                            "src": "/add-edges-to-make-degrees-of-all-nodes-even/",
+                            "score": 2060,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1579. 保证图可完全遍历",
+                            "sort": 4,
+                            "src": "/remove-max-number-of-edges-to-keep-graph-fully-traversable/",
+                            "score": 2132,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2065. 最大化一张图中的路径价值",
+                            "sort": 5,
+                            "src": "/maximum-path-quality-of-a-graph/",
+                            "score": 2178,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1697. 检查边长度限制的路径是否存在",
+                            "sort": 6,
+                            "src": "/checking-existence-of-edge-length-limited-paths/",
+                            "score": 2300,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2242. 节点序列的最大得分",
+                            "sort": 7,
+                            "src": "/maximum-score-of-a-node-sequence/",
+                            "score": 2304,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1928. 规定时间内到达终点的最小花费",
+                            "sort": 8,
+                            "src": "/minimum-cost-to-reach-destination-in-time/",
+                            "score": 2413,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2493. 将节点分成尽可能多的组",
+                            "sort": 9,
+                            "src": "/divide-nodes-into-the-maximum-number-of-groups/",
+                            "score": 2415,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1782. 统计点对的数目",
+                            "sort": 10,
+                            "src": "/count-pairs-of-nodes/",
+                            "score": 2457,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "277. 搜寻名人",
+                            "sort": 11,
+                            "src": "/find-the-celebrity/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1724. 检查边长度限制的路径是否存在 II",
+                            "sort": 12,
+                            "src": "/checking-existence-of-edge-length-limited-paths-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2077. 殊途同归",
+                            "sort": 13,
+                            "src": "/paths-in-maze-that-lead-to-same-room/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "LCP 16. 游乐园的游览计划",
+                            "sort": 14,
+                            "src": "/you-le-yuan-de-you-lan-ji-hua/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+} as ProblemCategory;

--- a/components/containers/List/data/greedy.ts
+++ b/components/containers/List/data/greedy.ts
@@ -267,7 +267,7 @@ export default{
                             "title": "2098. 长度为 K 的最大偶数和子序列",
                             "sort": 30,
                             "src": "/subsequence-of-size-k-with-the-largest-even-sum/",
-                            "score": 40,
+                            "score": null,
                             "solution": null,
                             "isPremium": true
                         },

--- a/components/containers/List/data/greedy.ts
+++ b/components/containers/List/data/greedy.ts
@@ -1,0 +1,2557 @@
+import ProblemCategory from "@components/ProblemCatetory";
+
+export default{
+    "title": "分享丨【题单】贪心算法（基本贪心策略/反悔/区间/字典序/数学/思维/构造）",
+    "original_src": "https://leetcode.cn/circle/discuss/g6KTKL",
+    "last_update": "2024-07-02T00:09:46.245243+00:00",
+    "sort": 0,
+    "child": [
+        {
+            "title": "前言",
+            "sort": 0,
+            "summary": "为方便大家练习，我把比较套路的贪心题目放在前面，更灵活的思维题和构造题放在后面。每个小节的题目均按照从易到难的顺序排列。<br>**如果做题时没有思路，推荐看看本文第五章的「思考清单」。**<br>",
+            "child": []
+        },
+        {
+            "title": "一、贪心策略",
+            "sort": 1,
+            "summary": "有两种**基本贪心策略**：<br>1. 从**最小/最大**开始贪心，优先考虑最小/最大的数。在此基础上，衍生出了**反悔贪心**。<br>2. 从**最左/最右**开始贪心，思考第一个数/最后一个数的贪心策略，把 $n$ 个数的原问题转换成 $n-1$ 个数（或更少）的子问题。<br>",
+            "child": [
+                {
+                    "title": "§1.1 从最小/最大开始贪心",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "优先考虑最小/最大的数，如何选择？如何修改？<br>如果答案与数组元素顺序无关，一般需要**排序**。排序后，可以遍历计算。<br>",
+                    "child": [
+                        {
+                            "title": "1833. 雪糕的最大数量",
+                            "sort": 0,
+                            "src": "/maximum-ice-cream-bars/",
+                            "score": 1253,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3074. 重新分装苹果",
+                            "sort": 1,
+                            "src": "/apple-redistribution-into-boxes/",
+                            "score": 1260,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2279. 装满石头的背包的最大数量",
+                            "sort": 2,
+                            "src": "/maximum-bags-with-full-capacity-of-rocks/",
+                            "score": 1260,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1005. K 次取反后最大化的数组和",
+                            "sort": 3,
+                            "src": "/maximize-sum-of-array-after-k-negations/",
+                            "score": 1275,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1481. 不同整数的最少数目",
+                            "sort": 4,
+                            "src": "/least-number-of-unique-integers-after-k-removals/",
+                            "score": 1284,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1403. 非递增顺序的最小子序列",
+                            "sort": 5,
+                            "src": "/minimum-subsequence-in-non-increasing-order/",
+                            "score": 1288,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1338. 数组大小减半",
+                            "sort": 6,
+                            "src": "/reduce-array-size-to-the-half/",
+                            "score": 1303,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1710. 卡车上的最大单元数",
+                            "sort": 7,
+                            "src": "/maximum-units-on-a-truck/",
+                            "score": 1310,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3075. 幸福值最大化的选择方案",
+                            "sort": 8,
+                            "src": "/maximize-happiness-of-selected-children/",
+                            "score": 1326,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2554. 从一个范围内选择最多整数 I",
+                            "sort": 9,
+                            "src": "/maximum-number-of-integers-to-choose-from-a-range-i/",
+                            "score": 1333,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2126. 摧毁小行星",
+                            "sort": 10,
+                            "src": "/destroying-asteroids/",
+                            "score": 1335,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2587. 重排数组以得到最大前缀分数",
+                            "sort": 11,
+                            "src": "/rearrange-array-to-maximize-prefix-score/",
+                            "score": 1337,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "976. 三角形的最大周长",
+                            "sort": 12,
+                            "src": "/largest-perimeter-triangle/",
+                            "score": 1341,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1846. 减小和重新排列数组后的最大元素",
+                            "sort": 13,
+                            "src": "/maximum-element-after-decreasing-and-rearranging/",
+                            "score": 1454,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "945. 使数组唯一的最小增量",
+                            "sort": 14,
+                            "src": "/minimum-increment-to-make-array-unique/",
+                            "score": 1448,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1647. 字符频次唯一的最小删除次数",
+                            "sort": 15,
+                            "src": "/minimum-deletions-to-make-character-frequencies-unique/",
+                            "score": 1510,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2971. 找到最大周长的多边形",
+                            "sort": 16,
+                            "src": "/find-polygon-with-the-largest-perimeter/",
+                            "score": 1521,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2178. 拆分成最多数目的正偶数之和",
+                            "sort": 17,
+                            "src": "/maximum-split-of-positive-even-integers/",
+                            "score": 1538,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2567. 修改两个元素的最小分数",
+                            "sort": 18,
+                            "src": "/minimum-score-by-changing-two-elements/",
+                            "score": 1609,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1509. 三次操作后最大值与最小值的最小差",
+                            "sort": 19,
+                            "src": "/minimum-difference-between-largest-and-smallest-value-in-three-moves/",
+                            "score": 1653,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCP 40. 心算挑战",
+                            "sort": 20,
+                            "src": "/uOAnQW/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1262. 可被三整除的最大和",
+                            "sort": 21,
+                            "src": "/greatest-sum-divisible-by-three/",
+                            "score": 1762,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "948. 令牌放置",
+                            "sort": 22,
+                            "src": "/bag-of-tokens/",
+                            "score": 1762,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1775. 通过最少操作次数使数组的和相等",
+                            "sort": 23,
+                            "src": "/equal-sum-arrays-with-minimum-number-of-operations/",
+                            "score": 1850,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2333. 最小差值平方和",
+                            "sort": 24,
+                            "src": "/minimum-sum-of-squared-difference/",
+                            "score": 2011,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2412. 完成所有交易的初始最少钱数",
+                            "sort": 25,
+                            "src": "/minimum-money-required-before-transactions/",
+                            "score": 2092,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "910. 最小差值 II",
+                            "sort": 26,
+                            "src": "/smallest-range-ii/",
+                            "score": 2135,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2835. 使子序列的和等于目标的最少操作次数",
+                            "sort": 27,
+                            "src": "/minimum-operations-to-form-subsequence-with-target-sum/",
+                            "score": 2207,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1196. 最多可以买到的苹果数量",
+                            "sort": 28,
+                            "src": "/how-many-apples-can-you-put-into-the-basket/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2214. 通关游戏所需的最低生命值",
+                            "sort": 29,
+                            "src": "/minimum-health-to-beat-game/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2098. 长度为 K 的最大偶数和子序列",
+                            "sort": 30,
+                            "src": "/subsequence-of-size-k-with-the-largest-even-sum/",
+                            "score": 40,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2548. 填满背包的最大价格",
+                            "sort": 31,
+                            "src": "/maximum-price-to-fill-a-bag/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "3119. 最大数量的可修复坑洼",
+                            "sort": 32,
+                            "src": "/maximum-number-of-potholes-that-can-be-fixed/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2557. 从一个范围内选择最多整数 II",
+                            "sort": 33,
+                            "src": "/maximum-number-of-integers-to-choose-from-a-range-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                },
+                {
+                    "title": "§1.2 单序列配对",
+                    "sort": 1,
+                    "isLeaf": true,
+                    "summary": "同上，从最小/最大的元素开始贪心。<br>",
+                    "child": [
+                        {
+                            "title": "2144. 打折购买糖果的最小开销",
+                            "sort": 0,
+                            "src": "/minimum-cost-of-buying-candies-with-discount/",
+                            "score": 1261,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "561. 数组拆分",
+                            "sort": 1,
+                            "src": "/array-partition/",
+                            "score": 1300,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1877. 数组中最大数对和的最小值",
+                            "sort": 2,
+                            "src": "/minimize-maximum-pair-sum-in-array/",
+                            "score": 1301,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "881. 救生艇",
+                            "sort": 3,
+                            "src": "/boats-to-save-people/",
+                            "score": 1530,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2592. 最大化数组的伟大值",
+                            "sort": 4,
+                            "src": "/maximize-greatness-of-an-array/",
+                            "score": 1569,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2576. 求出最多标记下标",
+                            "sort": 5,
+                            "src": "/find-the-maximum-number-of-marked-indices/",
+                            "score": 1843,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                },
+                {
+                    "title": "§1.3 双序列配对",
+                    "sort": 2,
+                    "isLeaf": true,
+                    "summary": "同上，从最小/最大的元素开始贪心。<br>",
+                    "child": [
+                        {
+                            "title": "2037. 使每位学生都有座位的最少移动次数",
+                            "sort": 0,
+                            "src": "/minimum-number-of-moves-to-seat-everyone/",
+                            "score": 1357,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "455. 分发饼干",
+                            "sort": 1,
+                            "src": "/assign-cookies/",
+                            "score": 1380,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2410. 运动员和训练师的最大匹配数",
+                            "sort": 2,
+                            "src": "/maximum-matching-of-players-with-trainers/",
+                            "score": 1381,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1433. 检查一个字符串是否可以打破另一个字符串",
+                            "sort": 3,
+                            "src": "/check-if-a-string-can-break-another-string/",
+                            "score": 1436,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "870. 优势洗牌",
+                            "sort": 4,
+                            "src": "/advantage-shuffle/",
+                            "score": 1648,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2449. 使数组相似的最少操作次数",
+                            "sort": 5,
+                            "src": "/minimum-number-of-operations-to-make-arrays-similar/",
+                            "score": 2076,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1889. 装包裹的最小浪费空间",
+                            "sort": 6,
+                            "src": "/minimum-space-wasted-from-packaging/",
+                            "score": 2214,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2561. 重排水果",
+                            "sort": 7,
+                            "src": "/rearranging-fruits/",
+                            "score": 2222,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2323. 完成所有工作的最短时间 II",
+                            "sort": 8,
+                            "src": "/find-minimum-time-to-finish-all-jobs-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                },
+                {
+                    "title": "§1.4 从最左/最右开始贪心",
+                    "sort": 3,
+                    "isLeaf": true,
+                    "summary": "对于无法排序的题目，尝试从左到右/从右到左贪心。思考第一个数/最后一个数的贪心策略，把 $n$ 个数的原问题转换成 $n-1$ 个数（或更少）的子问题。<br>读者可以对比下面的题目和 <a href=\"https://leetcode.cn/circle/discuss/tXLS3i/\">动态规划题单</a> 中的线性 DP、状态机 DP 的区别，思考什么情况下只能 DP 不能贪心，从而加深对「局部最优」和「全局最优」的理解。<br>",
+                    "child": [
+                        {
+                            "title": "1827. 最少操作使数组递增",
+                            "sort": 0,
+                            "src": "/minimum-operations-to-make-the-array-increasing/",
+                            "score": 1315,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2027. 转换字符串的最少操作次数",
+                            "sort": 1,
+                            "src": "/minimum-moves-to-convert-string/",
+                            "score": 1346,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3191. 使二进制数组全部等于 1 的最少操作次数 I",
+                            "sort": 2,
+                            "src": "/minimum-operations-to-make-binary-array-elements-equal-to-one-i/",
+                            "score": 1350,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "605. 种花问题",
+                            "sort": 3,
+                            "src": "/can-place-flowers/",
+                            "score": 1400,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3111. 覆盖所有点的最少矩形数目",
+                            "sort": 4,
+                            "src": "/minimum-rectangles-to-cover-points/",
+                            "score": 1401,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2957. 消除相邻近似相等字符",
+                            "sort": 5,
+                            "src": "/remove-adjacent-almost-equal-characters/",
+                            "score": 1430,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2789. 合并后数组中的最大元素",
+                            "sort": 6,
+                            "src": "/largest-element-in-an-array-after-merge-operations/",
+                            "score": 1485,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3192. 使二进制数组全部等于 1 的最少操作次数 II",
+                            "sort": 7,
+                            "src": "/minimum-operations-to-make-binary-array-elements-equal-to-one-ii/",
+                            "score": 1550,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1529. 最少的后缀翻转次数",
+                            "sort": 8,
+                            "src": "/minimum-suffix-flips/",
+                            "score": 3192,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1144. 递减元素使数组呈锯齿状",
+                            "sort": 9,
+                            "src": "/decrease-elements-to-make-array-zigzag/",
+                            "score": 1559,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2086. 喂食仓鼠的最小食物桶数",
+                            "sort": 10,
+                            "src": "/minimum-number-of-food-buckets-to-feed-the-hamsters/",
+                            "score": 1623,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2571. 将整数减少到零需要的最少操作数",
+                            "sort": 11,
+                            "src": "/minimum-operations-to-reduce-an-integer-to-0/",
+                            "score": 1649,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2712. 使所有字符相等的最小成本",
+                            "sort": 12,
+                            "src": "/minimum-cost-to-make-all-characters-equal/",
+                            "score": 1791,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1536. 排布二进制网格的最少交换次数",
+                            "sort": 13,
+                            "src": "/minimum-swaps-to-arrange-a-binary-grid/",
+                            "score": 1881,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2673. 使二叉树所有路径值相等的最小代价",
+                            "sort": 14,
+                            "src": "/make-costs-of-paths-equal-in-a-binary-tree/",
+                            "score": 1917,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "861. 翻转矩阵后的得分",
+                            "sort": 15,
+                            "src": "/score-after-flipping-matrix/",
+                            "score": 2000,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "955. 删列造序 II",
+                            "sort": 16,
+                            "src": "/delete-columns-to-make-sorted-ii/",
+                            "score": 2000,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2366. 将数组排序的最少替换次数",
+                            "sort": 17,
+                            "src": "/minimum-replacements-to-sort-the-array/",
+                            "score": 2060,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2193. 得到回文串的最少操作次数",
+                            "sort": 18,
+                            "src": "/minimum-number-of-moves-to-make-palindrome/",
+                            "score": 2091,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2528. 最大化城市的最小电量",
+                            "sort": 19,
+                            "src": "/maximize-the-minimum-powered-city/",
+                            "score": 2236,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2422. 使用合并操作将数组转换为回文序列",
+                            "sort": 20,
+                            "src": "/merge-operations-to-turn-array-into-a-palindrome/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                },
+                {
+                    "title": "§1.5 划分型贪心",
+                    "sort": 4,
+                    "isLeaf": true,
+                    "summary": "把数组/字符串划分成满足要求的若干段，最小化/最大化划分的段数。<br>思考方法同上，尝试从左到右/从右到左贪心。<br>读者可以对比下面的题目和 <a href=\"https://leetcode.cn/circle/discuss/tXLS3i/\">动态规划题单</a> 中的划分型 DP 的区别，思考什么情况下只能 DP 不能贪心，从而加深对「局部最优」和「全局最优」的理解。<br>",
+                    "child": [
+                        {
+                            "title": "1221. 分割平衡字符串",
+                            "sort": 0,
+                            "src": "/split-a-string-in-balanced-strings/",
+                            "score": 1220,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2405. 子字符串的最优划分",
+                            "sort": 1,
+                            "src": "/optimal-partition-of-string/",
+                            "score": 1355,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2294. 划分数组使最大差为 K",
+                            "sort": 2,
+                            "src": "/partition-array-such-that-maximum-difference-is-k/",
+                            "score": 1416,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2358. 分组的最大数量",
+                            "sort": 3,
+                            "src": "/maximum-number-of-groups-entering-a-competition/",
+                            "score": 1503,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2522. 将字符串分割成值不超过 K 的子字符串",
+                            "sort": 4,
+                            "src": "/partition-string-into-substrings-with-values-at-most-k/",
+                            "score": 1605,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1546. 和为目标值且不重叠的非空子数组的最大数目",
+                            "sort": 5,
+                            "src": "/maximum-number-of-non-overlapping-subarrays-with-sum-equals-target/",
+                            "score": 1855,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2436. 使子数组最大公约数大于一的最小分割数",
+                            "sort": 6,
+                            "src": "/minimum-split-into-subarrays-with-gcd-greater-than-one/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2892. 将相邻元素相乘后得到最小化数组",
+                            "sort": 7,
+                            "src": "/minimizing-array-after-replacing-pairs-with-their-product/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                },
+                {
+                    "title": "§1.6 先枚举，再贪心",
+                    "sort": 5,
+                    "isLeaf": true,
+                    "summary": "枚举题目的其中一个变量，将其视作已知条件，然后在此基础上贪心。<br>也可以枚举答案，检查是否可以满足要求。（类似二分答案）<br>",
+                    "child": [
+                        {
+                            "title": "1007. 行相等的最少多米诺旋转",
+                            "sort": 0,
+                            "src": "/minimum-domino-rotations-for-equal-row/",
+                            "score": 1541,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2171. 拿出最少数目的魔法豆",
+                            "sort": 1,
+                            "src": "/removing-minimum-number-of-magic-beans/",
+                            "score": 1748,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3085. 成为 K 特殊字符串需要删除的最少字符数",
+                            "sort": 2,
+                            "src": "/minimum-deletions-to-make-string-k-special/",
+                            "score": 1765,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1727. 重新排列后的最大子矩阵",
+                            "sort": 3,
+                            "src": "/largest-submatrix-with-rearrangements/",
+                            "score": 1927,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2749. 得到整数零需要执行的最少操作数",
+                            "sort": 4,
+                            "src": "/minimum-operations-to-make-the-integer-zero/",
+                            "score": 2132,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2910. 合法分组的最少组数",
+                            "sort": 5,
+                            "src": "/minimum-number-of-groups-to-create-a-valid-assignment/",
+                            "score": 2132,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2234. 花园的最大总美丽值",
+                            "sort": 6,
+                            "src": "/maximum-total-beauty-of-the-gardens/",
+                            "score": 2562,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                },
+                {
+                    "title": "§1.7 交换论证法",
+                    "sort": 6,
+                    "isLeaf": true,
+                    "summary": "交换论证法（exchange argument）用于证明一类贪心算法的正确性，也可以用来启发思考。做法如下：<br>1. 对于题目，猜想按照「某种顺序」处理数据，可以得到最优解。<br>2. 交换顺序中的两个元素 $a_i$ 和 $a_j$，计算交换后的答案。<br>3. 对比交换前后的答案。如果交换后，答案没有变得更优，则说明猜想成立。<br>**注**：也可以不用猜想，而是计算「先 $a_i$ 后 $a_j$」和「先 $a_j$ 后 $a_i$」对应的答案，通过比较两个答案谁更优，来确定按照何种顺序处理数据。<br><a href=\"https://leetcode.cn/problems/minimum-processing-time/solution/tan-xin-pythonjavacgo-by-endlesscheng-8fzf/\">讲解（以 2895 题为例）</a><br>**注**：该方法也可以用来证明一些配对问题的贪心算法，例如 <a href=\"https://leetcode.cn/problems/minimum-number-of-operations-to-make-arrays-similar/\">2449. 使数组相似的最少操作次数</a>。<br>",
+                    "child": [
+                        {
+                            "title": "2895. 最小处理时间",
+                            "sort": 0,
+                            "src": "/minimum-processing-time/",
+                            "score": 1352,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1665. 完成所有任务的最少初始能量",
+                            "sort": 1,
+                            "src": "/minimum-initial-energy-to-finish-tasks/",
+                            "score": 1901,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2136. 全部开花的最早一天",
+                            "sort": 2,
+                            "src": "/earliest-possible-day-of-full-bloom/",
+                            "score": 2033,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                },
+                {
+                    "title": "§1.8 相邻不同",
+                    "sort": 7,
+                    "isLeaf": true,
+                    "summary": "给定正整数数组，每次操作，把数组中的两个数各减少一，并去掉变成 $0$ 的数。目标：使最后剩下的数最小，或者最大化操作次数。<br>由于每次操作的都是两个下标不同的数，把这些下标按顺序拼接，可以构造出一个相邻元素不同的序列。例如 $(1,2),(2,3),(3,4)$ 这三个操作，可以拼接成 $<a href=\"https://leetcode.cn/problems/reorganize-string/solution/tan-xin-gou-zao-pai-xu-bu-pai-xu-liang-c-h9jg/\">1,2,3,2,3,4]$。<br>[证明/构造方案</a><br>**扩展**：<br>",
+                    "child": [
+                        {
+                            "title": "2335. 装满杯子需要的最短总时长",
+                            "sort": 0,
+                            "src": "/minimum-amount-of-time-to-fill-cups/",
+                            "score": 1360,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1753. 移除石子的最大得分",
+                            "sort": 1,
+                            "src": "/maximum-score-from-removing-stones/",
+                            "score": 1488,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1054. 距离相等的条形码",
+                            "sort": 2,
+                            "src": "/distant-barcodes/",
+                            "score": 1702,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2856. 删除数对后的最小数组长度",
+                            "sort": 3,
+                            "src": "/minimum-array-length-after-pair-removals/",
+                            "score": 1750,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1953. 你可以工作的最大周数",
+                            "sort": 4,
+                            "src": "/maximum-number-of-weeks-for-which-you-can-work/",
+                            "score": 1804,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "767. 重构字符串",
+                            "sort": 5,
+                            "src": "/reorganize-string/",
+                            "score": 1900,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3139. 使数组中所有元素相等的最小开销",
+                            "sort": 6,
+                            "src": "/minimum-cost-to-equalize-array/",
+                            "score": 2666,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "621. 任务调度器",
+                            "sort": 7,
+                            "src": "/task-scheduler/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "358. K 距离间隔重排字符串",
+                            "sort": 8,
+                            "src": "/rearrange-string-k-distance-apart/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "984. 不含 AAA 或 BBB 的字符串",
+                            "sort": 9,
+                            "src": "/string-without-aaa-or-bbb/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1405. 最长快乐字符串",
+                            "sort": 10,
+                            "src": "/longest-happy-string/",
+                            "score": 1821,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                },
+                {
+                    "title": "§1.9 反悔贪心",
+                    "sort": 8,
+                    "isLeaf": true,
+                    "summary": "一般要用到**堆**。<br><a href=\"https://leetcode.cn/problems/p0NxJO/solution/fan-hui-tan-xin-fu-ti-dan-pythonjavacgoj-hxup/\">讲解</a><br>> 注：在网络流中，寻找增广路的过程也是一种反悔贪心。<br>",
+                    "child": [
+                        {
+                            "title": "LCP 30. 魔塔游戏",
+                            "sort": 0,
+                            "src": "/p0NxJO/",
+                            "score": 1900,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1642. 可以到达的最远建筑",
+                            "sort": 1,
+                            "src": "/furthest-building-you-can-reach/",
+                            "score": 1962,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "630. 课程表 III",
+                            "sort": 2,
+                            "src": "/course-schedule-iii/",
+                            "score": 2000,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "871. 最低加油次数",
+                            "sort": 3,
+                            "src": "/minimum-number-of-refueling-stops/",
+                            "score": 2074,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2813. 子序列最大优雅度",
+                            "sort": 4,
+                            "src": "/maximum-elegance-of-a-k-length-subsequence/",
+                            "score": 2582,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3049. 标记所有下标的最早秒数 II",
+                            "sort": 5,
+                            "src": "/earliest-second-to-mark-indices-ii/",
+                            "score": 3111,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2463. 最小移动总距离",
+                            "sort": 6,
+                            "src": "/minimum-total-distance-traveled/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2599. 使前缀和数组非负",
+                            "sort": 7,
+                            "src": "/make-the-prefix-sum-non-negative/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "二、区间贪心",
+            "sort": 2,
+            "summary": "区间贪心有如下经典问题：<br>- **不相交区间**（单机器调度/活动安排）：给定一些区间，从中选出尽量多的两两互不相交的区间。<br>- **区间分组**（任务调度/会议室）：给定一些区间，把这些区间分成最少的组，使得每组内的区间互不相交。<br>- **区间选点**（射气球）：给定一些区间，在数轴上放置最少的点，使得每个区间都包含至少一个点。<br>- **区间覆盖**（灌溉花园）：给定一些区间，从中选出尽量少的区间，覆盖一条指定线段 $[s,t]$。<br>**任务**：总结上述四种区间贪心问题的解法，尤其是排序的规则和理由，什么时候要按照左端点排序？什么时候要按照右端点排序？排序的目的是什么？欢迎在评论区分享你的总结笔记。<br>",
+            "child": [
+                {
+                    "title": "§2.1 不相交区间",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "**变形**：每个区间有各自的分数，从中选一些两两互不相交的区间，最大化得分之和。详见 <a href=\"https://leetcode.cn/circle/discuss/tXLS3i/\">动态规划题单</a> 中的「§6.4 不相交区间」。<br>",
+                    "child": [
+                        {
+                            "title": "646. 最长数对链",
+                            "sort": 0,
+                            "src": "/maximum-length-of-pair-chain/",
+                            "score": 1700,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "435. 无重叠区间",
+                            "sort": 1,
+                            "src": "/non-overlapping-intervals/",
+                            "score": 1750,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1520. 最多的不重叠子字符串",
+                            "sort": 2,
+                            "src": "/maximum-number-of-non-overlapping-substrings/",
+                            "score": 2363,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                },
+                {
+                    "title": "§2.2 区间分组",
+                    "sort": 1,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "2406. 将区间分为最少组数",
+                            "sort": 0,
+                            "src": "/divide-intervals-into-minimum-number-of-groups/",
+                            "score": 1713,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "253. 会议室 II",
+                            "sort": 1,
+                            "src": "/meeting-rooms-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                },
+                {
+                    "title": "§2.3 区间选点",
+                    "sort": 2,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "452. 用最少数量的箭引爆气球",
+                            "sort": 0,
+                            "src": "/minimum-number-of-arrows-to-burst-balloons/",
+                            "score": 1700,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "757. 设置交集大小至少为2",
+                            "sort": 1,
+                            "src": "/set-intersection-size-at-least-two/",
+                            "score": 2379,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                },
+                {
+                    "title": "§2.4 区间覆盖",
+                    "sort": 3,
+                    "isLeaf": true,
+                    "summary": "<a href=\"https://leetcode.cn/problems/minimum-number-of-taps-to-open-to-water-a-garden/solution/yi-zhang-tu-miao-dong-pythonjavacgo-by-e-wqry/\">图解</a><br>",
+                    "child": [
+                        {
+                            "title": "45. 跳跃游戏 II",
+                            "sort": 0,
+                            "src": "/jump-game-ii/",
+                            "score": 1700,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1024. 视频拼接",
+                            "sort": 1,
+                            "src": "/video-stitching/",
+                            "score": 1746,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1326. 灌溉花园的最少水龙头数目",
+                            "sort": 2,
+                            "src": "/minimum-number-of-taps-to-open-to-water-a-garden/",
+                            "score": 1885,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                },
+                {
+                    "title": "§2.5 合并区间",
+                    "sort": 4,
+                    "isLeaf": true,
+                    "summary": "> 可能算不上贪心，但为了题单的完整性，也放到这个分类中。<br>",
+                    "child": [
+                        {
+                            "title": "56. 合并区间",
+                            "sort": 0,
+                            "src": "/merge-intervals/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "57. 插入区间",
+                            "sort": 1,
+                            "src": "/insert-interval/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "55. 跳跃游戏",
+                            "sort": 2,
+                            "src": "/jump-game/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "763. 划分字母区间",
+                            "sort": 3,
+                            "src": "/partition-labels/",
+                            "score": 1443,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3169. 无需开会的工作日",
+                            "sort": 4,
+                            "src": "/count-days-without-meetings/",
+                            "score": 1483,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2580. 统计将重叠区间合并成组的方案数",
+                            "sort": 5,
+                            "src": "/count-ways-to-group-overlapping-ranges/",
+                            "score": 1632,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2963. 统计好分割方案的数目",
+                            "sort": 6,
+                            "src": "/count-the-number-of-good-partitions/",
+                            "score": 1985,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2584. 分割数组使乘积互质",
+                            "sort": 7,
+                            "src": "/split-the-array-to-make-coprime-products/",
+                            "score": 2159,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "616. 给字符串添加加粗标签",
+                            "sort": 8,
+                            "src": "/add-bold-tag-in-string/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "758. 字符串中的加粗单词",
+                            "sort": 9,
+                            "src": "/bold-words-in-string/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "759. 员工空闲时间",
+                            "sort": 10,
+                            "src": "/employee-free-time/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2655. 寻找最大长度的未覆盖区间",
+                            "sort": 11,
+                            "src": "/find-maximal-uncovered-ranges/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                },
+                {
+                    "title": "§2.6 其他区间贪心",
+                    "sort": 5,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "1288. 删除被覆盖区间",
+                            "sort": 0,
+                            "src": "/remove-covered-intervals/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2054. 两个最好的不重叠活动",
+                            "sort": 1,
+                            "src": "/two-best-non-overlapping-events/",
+                            "score": 1883,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1705. 吃苹果的最大数目",
+                            "sort": 2,
+                            "src": "/maximum-number-of-eaten-apples/",
+                            "score": 1930,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1353. 最多可以参加的会议数目",
+                            "sort": 3,
+                            "src": "/maximum-number-of-events-that-can-be-attended/",
+                            "score": 2016,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2589. 完成所有任务的最少时间",
+                            "sort": 4,
+                            "src": "/minimum-time-to-complete-all-tasks/",
+                            "score": 2381,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "三、字符串贪心",
+            "sort": 3,
+            "summary": "",
+            "child": [
+                {
+                    "title": "§3.1 字典序最小/最大",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "**字典序**的定义如下：<br>- 对于两个字符串 $a$ 和 $b$，从左到右依次比较 $a[i]$ 和 $b[i]$ 的字符 ASCII 值的大小。<br>- $a[i]\\ne b[i]$ 时，如果 $a[i]<b[i]$，那么 $a$ 的字典序更小，否则 $b$ 的字典序更小。<br>- 如果没有出现 $a[i]\\ne b[i]$，则短的字符串字典序更小。<br>- 如果两个字符串的长度和内容均相同，那么两个字符串的字典序一样。<br>字典序的定义也可以推广到数组上，按照上述方法比较两个数组的字典序。<br>",
+                    "child": [
+                        {
+                            "title": "1323. 6 和 9 组成的最大数字",
+                            "sort": 0,
+                            "src": "/maximum-69-number/",
+                            "score": 1194,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2697. 字典序最小回文串",
+                            "sort": 1,
+                            "src": "/lexicographically-smallest-palindrome/",
+                            "score": 1304,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1881. 插入后的最大值",
+                            "sort": 2,
+                            "src": "/maximum-value-after-insertion/",
+                            "score": 1381,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2734. 执行子串操作后的字典序最小字符串",
+                            "sort": 3,
+                            "src": "/lexicographically-smallest-string-after-substring-operation/",
+                            "score": 1405,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1946. 子字符串突变后可能得到的最大整数",
+                            "sort": 4,
+                            "src": "/largest-number-after-mutating-substring/",
+                            "score": 1445,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1663. 具有给定数值的最小字符串",
+                            "sort": 5,
+                            "src": "/smallest-string-with-a-given-numeric-value/",
+                            "score": 1461,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1328. 破坏回文串",
+                            "sort": 6,
+                            "src": "/break-a-palindrome/",
+                            "score": 1474,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2259. 移除指定数字得到的最大结果",
+                            "sort": 7,
+                            "src": "/remove-digit-from-number-to-maximize-result/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2566. 替换一个数字后的最大差值",
+                            "sort": 8,
+                            "src": "/maximum-difference-by-remapping-a-digit/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "670. 最大交换",
+                            "sort": 9,
+                            "src": "/maximum-swap/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3106. 满足距离约束且字典序最小的字符串",
+                            "sort": 10,
+                            "src": "/lexicographically-smallest-string-after-operations-with-constraint/",
+                            "score": 1515,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1053. 交换一次的先前排列",
+                            "sort": 11,
+                            "src": "/previous-permutation-with-one-swap/",
+                            "score": 1633,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2375. 根据模式串构造最小数字",
+                            "sort": 12,
+                            "src": "/construct-smallest-number-from-di-string/",
+                            "score": 1642,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2182. 构造限制重复的字符串",
+                            "sort": 13,
+                            "src": "/construct-string-with-repeat-limit/",
+                            "score": 1680,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "738. 单调递增的数字",
+                            "sort": 14,
+                            "src": "/monotone-increasing-digits/",
+                            "score": 1700,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3170. 删除星号以后字典序最小的字符串",
+                            "sort": 15,
+                            "src": "/lexicographically-minimum-string-after-removing-stars/",
+                            "score": 1772,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1363. 形成三的最大倍数",
+                            "sort": 16,
+                            "src": "/largest-multiple-of-three/",
+                            "score": 1823,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1754. 构造字典序最大的合并字符串",
+                            "sort": 17,
+                            "src": "/largest-merge-of-two-strings/",
+                            "score": 1829,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1202. 交换字符串中的元素",
+                            "sort": 18,
+                            "src": "/smallest-string-with-swaps/",
+                            "score": 1855,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2434. 使用机器人打印字典序最小的字符串",
+                            "sort": 19,
+                            "src": "/using-a-robot-to-print-the-lexicographically-smallest-string/",
+                            "score": 1953,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2948. 交换得到字典序最小的数组",
+                            "sort": 20,
+                            "src": "/make-lexicographically-smallest-array-by-swapping-elements/",
+                            "score": 2047,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "564. 寻找最近的回文数",
+                            "sort": 21,
+                            "src": "/find-the-closest-palindrome/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1505. 最多 K 次交换相邻数位后得到的最小整数",
+                            "sort": 22,
+                            "src": "/minimum-possible-integer-after-at-most-k-adjacent-swaps-on-digits/",
+                            "score": 2337,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2663. 字典序最小的美丽字符串",
+                            "sort": 23,
+                            "src": "/lexicographically-smallest-beautiful-string/",
+                            "score": 2416,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "555. 分割连接字符串",
+                            "sort": 24,
+                            "src": "/split-concatenated-strings/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "3088. 使字符串反回文",
+                            "sort": 25,
+                            "src": "/make-string-anti-palindrome/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                },
+                {
+                    "title": "§3.2 回文串贪心",
+                    "sort": 1,
+                    "isLeaf": true,
+                    "summary": "> 部分题目也出现在其他贪心分类中，为了题单的完整性整理到一起。<br>",
+                    "child": [
+                        {
+                            "title": "409. 最长回文串",
+                            "sort": 0,
+                            "src": "/longest-palindrome/",
+                            "score": 1250,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2697. 字典序最小回文串",
+                            "sort": 1,
+                            "src": "/lexicographically-smallest-palindrome/",
+                            "score": 1304,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1328. 破坏回文串",
+                            "sort": 2,
+                            "src": "/break-a-palindrome/",
+                            "score": 1474,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1400. 构造 K 个回文字符串",
+                            "sort": 3,
+                            "src": "/construct-k-palindrome-strings/",
+                            "score": 1530,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2131. 连接两字母单词得到的最长回文串",
+                            "sort": 4,
+                            "src": "/longest-palindrome-by-concatenating-two-letter-words/",
+                            "score": 1557,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2384. 最大回文数字",
+                            "sort": 5,
+                            "src": "/largest-palindromic-number/",
+                            "score": 1636,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3035. 回文字符串的最大数量",
+                            "sort": 6,
+                            "src": "/maximum-palindromes-after-operations/",
+                            "score": 1857,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1616. 分割两个字符串得到回文串",
+                            "sort": 7,
+                            "src": "/split-two-strings-to-make-palindrome/",
+                            "score": 1868,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1147. 段式回文",
+                            "sort": 8,
+                            "src": "/longest-chunked-palindrome-decomposition/",
+                            "score": 1912,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2193. 得到回文串的最少操作次数",
+                            "sort": 9,
+                            "src": "/minimum-number-of-moves-to-make-palindrome/",
+                            "score": 2091,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "564. 寻找最近的回文数",
+                            "sort": 10,
+                            "src": "/find-the-closest-palindrome/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "266. 回文排列",
+                            "sort": 11,
+                            "src": "/palindrome-permutation/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2422. 使用合并操作将数组转换为回文序列",
+                            "sort": 12,
+                            "src": "/merge-operations-to-turn-array-into-a-palindrome/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "3088. 使字符串反回文",
+                            "sort": 13,
+                            "src": "/make-string-anti-palindrome/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "四、数学贪心",
+            "sort": 4,
+            "summary": "",
+            "child": [
+                {
+                    "title": "§4.1 基础",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "2160. 拆分数位后四位数字的最小和",
+                            "sort": 0,
+                            "src": "/minimum-sum-of-four-digit-number-after-splitting-digits/",
+                            "score": 1314,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2578. 最小和分割",
+                            "sort": 1,
+                            "src": "/split-with-minimum-sum/",
+                            "score": 1351,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2244. 完成所有任务需要的最少轮数",
+                            "sort": 2,
+                            "src": "/minimum-rounds-to-complete-all-tasks/",
+                            "score": 1372,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2870. 使数组为空的最少操作次数",
+                            "sort": 3,
+                            "src": "/minimum-number-of-operations-to-make-array-empty/",
+                            "score": 1392,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1217. 玩筹码",
+                            "sort": 4,
+                            "src": "/minimum-cost-to-move-chips-to-the-same-position/",
+                            "score": 1408,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCS 01. 下载插件",
+                            "sort": 5,
+                            "src": "/Ju9Xwi/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3091. 执行操作使数据元素之和大于等于 K",
+                            "sort": 6,
+                            "src": "/apply-operations-to-make-sum-of-array-greater-than-or-equal-to-k/",
+                            "score": 1522,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "397. 整数替换",
+                            "sort": 7,
+                            "src": "/integer-replacement/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                },
+                {
+                    "title": "§4.2 乘积贪心",
+                    "sort": 1,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "628. 三个数的最大乘积",
+                            "sort": 0,
+                            "src": "/maximum-product-of-three-numbers/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1567. 乘积为正数的最长子数组长度",
+                            "sort": 1,
+                            "src": "/maximum-length-of-subarray-with-positive-product/",
+                            "score": 1710,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                },
+                {
+                    "title": "§4.3 排序不等式",
+                    "sort": 2,
+                    "isLeaf": true,
+                    "summary": "给定两个长度均为 $n$ 的数组 $a$ 和 $b$，可以交换同一数组内的元素，最小化/最大化<br>$$<br>a[0]\\cdot b[0] + a[1]\\cdot b[1] +\\cdots+ a[n-1]\\cdot b[n-1]<br>$$<br>把 $a$ 和 $b$ 都从小到大排序，可以最大化上式。<br>把 $a$ 从小到大排序，$b$ 从大到小排序，可以最小化上式。<br>",
+                    "child": [
+                        {
+                            "title": "2285. 道路的最大总重要性",
+                            "sort": 0,
+                            "src": "/maximum-total-importance-of-roads/",
+                            "score": 1496,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3016. 输入单词需要的最少按键次数 II",
+                            "sort": 1,
+                            "src": "/minimum-number-of-pushes-to-type-word-ii/",
+                            "score": 1534,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1402. 做菜顺序",
+                            "sort": 2,
+                            "src": "/reducing-dishes/",
+                            "score": 1679,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2931. 购买物品的最大开销",
+                            "sort": 3,
+                            "src": "/maximum-spending-after-buying-items/",
+                            "score": 1822,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1589. 所有排列中的最大和",
+                            "sort": 4,
+                            "src": "/maximum-sum-obtained-of-any-permutation/",
+                            "score": 1871,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1874. 两个数组的最小乘积和",
+                            "sort": 5,
+                            "src": "/minimize-product-sum-of-two-arrays/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2268. 最少按键次数",
+                            "sort": 6,
+                            "src": "/minimum-number-of-keypresses/",
+                            "score": 3016,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                },
+                {
+                    "title": "§4.4 基本不等式",
+                    "sort": 3,
+                    "isLeaf": true,
+                    "summary": "**栅栏问题**：长为 $n$ 米的篱笆栅栏，围成一个矩形，矩形面积最大是多少？<br>**变形**：长为 $n$ 米的栅栏分成 $k$ 份，每份围成一个正方形，面积之和最小是多少？<br>",
+                    "child": [
+                        {
+                            "title": "3081. 替换字符串中的问号使分数最小",
+                            "sort": 0,
+                            "src": "/replace-question-marks-in-string-to-minimize-its-value/",
+                            "score": 1905,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1969. 数组元素的最小非零乘积",
+                            "sort": 1,
+                            "src": "/minimum-non-zero-product-of-the-array-elements/",
+                            "score": 1967,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2939. 最大异或乘积",
+                            "sort": 2,
+                            "src": "/maximum-xor-product/",
+                            "score": 2128,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2897. 对数组执行操作使平方和最大",
+                            "sort": 3,
+                            "src": "/apply-operations-on-array-to-maximize-sum-of-squares/",
+                            "score": 2301,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                },
+                {
+                    "title": "§4.5 中位数贪心",
+                    "sort": 4,
+                    "isLeaf": true,
+                    "summary": "给定数组，每次操作可以把其中一个数加一/减一，把所有数都变成一样的，最少要操作多少次？<br>把所有数都变成数组的**中位数**是最优的。<br><a href=\"https://leetcode.cn/problems/5TxKeK/solution/zhuan-huan-zhong-wei-shu-tan-xin-dui-din-7r9b/\">两种证明方法</a><br>",
+                    "child": [
+                        {
+                            "title": "462. 最小操作次数使数组元素相等 II",
+                            "sort": 0,
+                            "src": "/minimum-moves-to-equal-array-elements-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2033. 获取单值网格的最小操作数",
+                            "sort": 1,
+                            "src": "/minimum-operations-to-make-a-uni-value-grid/",
+                            "score": 1672,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2448. 使数组相等的最小开销",
+                            "sort": 2,
+                            "src": "/minimum-cost-to-make-array-equal/",
+                            "score": 2005,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2607. 使子数组元素和相等",
+                            "sort": 3,
+                            "src": "/make-k-subarray-sums-equal/",
+                            "score": 2071,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2967. 使数组成为等数数组的最小代价",
+                            "sort": 4,
+                            "src": "/minimum-cost-to-make-array-equalindromic/",
+                            "score": 2116,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1478. 安排邮筒",
+                            "sort": 5,
+                            "src": "/allocate-mailboxes/",
+                            "score": 2190,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2968. 执行操作使频率分数最大",
+                            "sort": 6,
+                            "src": "/apply-operations-to-maximize-frequency-score/",
+                            "score": 2444,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1703. 得到连续 K 个 1 的最少相邻交换次数",
+                            "sort": 7,
+                            "src": "/minimum-adjacent-swaps-for-k-consecutive-ones/",
+                            "score": 2467,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3086. 拾起 K 个 1 需要的最少行动次数",
+                            "sort": 8,
+                            "src": "/minimum-moves-to-pick-k-ones/",
+                            "score": 2673,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCP 24. 数字游戏",
+                            "sort": 9,
+                            "src": "/5TxKeK/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "296. 最佳的碰头地点",
+                            "sort": 10,
+                            "src": "/best-meeting-point/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                },
+                {
+                    "title": "§4.6 归纳法",
+                    "sort": 5,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "2952. 需要添加的硬币的最小数量",
+                            "sort": 0,
+                            "src": "/minimum-number-of-coins-to-be-added/",
+                            "score": 1784,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "330. 按要求补齐数组",
+                            "sort": 1,
+                            "src": "/patching-array/",
+                            "score": 2952,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1798. 你能构造出连续值的最大数目",
+                            "sort": 2,
+                            "src": "/maximum-number-of-consecutive-values-you-can-make/",
+                            "score": 1931,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                },
+                {
+                    "title": "§4.7 其他数学贪心",
+                    "sort": 6,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "1414. 和为 K 的最少斐波那契数字数目",
+                            "sort": 0,
+                            "src": "/find-the-minimum-number-of-fibonacci-numbers-whose-sum-is-k/",
+                            "score": 1466,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3107. 使数组中位数等于 K 的最少操作数",
+                            "sort": 1,
+                            "src": "/minimum-operations-to-make-median-of-array-equal-to-k/",
+                            "score": 1605,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "754. 到达终点数字",
+                            "sort": 2,
+                            "src": "/reach-a-number/",
+                            "score": 2000,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1058. 最小化舍入误差以满足目标",
+                            "sort": 3,
+                            "src": "/minimize-rounding-error-to-meet-target/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "五、思维题",
+            "sort": 5,
+            "summary": "回想一下高考数学的最后一题，三个小问，前两小问让你计算一些特殊情况，第三小问让你计算/证明一个一般的结论。这其实就是**从特殊到一般**的思考方式，我们在做算法题（尤其是思维题和构造题）时，也可以从最简单、最特殊的情况开始，去探索题目的性质，逐渐过渡到一般情况。<br>**思考清单**<br>- **小型数组**：$\\textit{nums}$ 只有 $1$ 个数？只有 $2$ 个数？只有 $3$ 个数？<br>- **万里挑一**：$\\textit{nums}$ 所有数都相同？只有一个数不一样？有两个数不一样？某个数特别大？<br>- **黑白世界**：只有两种数？例如 $[0,1,0,1,0,1]$ 或者 $\\texttt{ababab}$。<br>- **反向思考**：如果答案是 $1$，输入会是什么样的？如果答案是 $2$？是 $\\textit{nums}[0]$？是 $\\textit{nums}[1]$？<br>- **枚举归纳**：试试小范围打表，暴力枚举所有情况，找规律。<br>思考这些特殊情况，有时会产生求解原问题的**灵感**。<br>",
+            "child": [
+                {
+                    "title": "§5.1 从特殊到一般",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "2645. 构造有效字符串的最少插入数",
+                            "sort": 0,
+                            "src": "/minimum-additions-to-make-valid-string/",
+                            "score": 1478,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2745. 构造最长的新字符串",
+                            "sort": 1,
+                            "src": "/construct-the-longest-new-string/",
+                            "score": 1607,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2611. 老鼠和奶酪",
+                            "sort": 2,
+                            "src": "/mice-and-cheese/",
+                            "score": 1663,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1029. 两地调度",
+                            "sort": 3,
+                            "src": "/two-city-scheduling/",
+                            "score": 2611,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2202. K 次操作后最大化顶端元素",
+                            "sort": 4,
+                            "src": "/maximize-the-topmost-element-after-k-moves/",
+                            "score": 1717,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2568. 最小无法得到的或值",
+                            "sort": 5,
+                            "src": "/minimum-impossible-or/",
+                            "score": 1754,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1702. 修改后的最大二进制字符串",
+                            "sort": 6,
+                            "src": "/maximum-binary-string-after-change/",
+                            "score": 1825,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3012. 通过操作使数组长度最小",
+                            "sort": 7,
+                            "src": "/minimize-length-of-array-using-operations/",
+                            "score": 1833,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1526. 形成目标数组的子数组最少增加次数",
+                            "sort": 8,
+                            "src": "/minimum-number-of-increments-on-subarrays-to-form-a-target-array/",
+                            "score": 1872,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2350. 不可能得到的最短骰子序列",
+                            "sort": 9,
+                            "src": "/shortest-impossible-sequence-of-rolls/",
+                            "score": 1961,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "517. 超级洗衣机",
+                            "sort": 10,
+                            "src": "/super-washing-machines/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2499. 让数组不相等的最小总代价",
+                            "sort": 11,
+                            "src": "/minimum-total-cost-to-make-arrays-unequal/",
+                            "score": 2633,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                },
+                {
+                    "title": "§5.2 脑筋急转弯",
+                    "sort": 1,
+                    "isLeaf": true,
+                    "summary": "从一般到特殊。<br>",
+                    "child": [
+                        {
+                            "title": "1903. 字符串中的最大奇数",
+                            "sort": 0,
+                            "src": "/largest-odd-number-in-string/",
+                            "score": 1249,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2396. 严格回文的数字",
+                            "sort": 1,
+                            "src": "/strictly-palindromic-number/",
+                            "score": 1329,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1689. 十-二进制数的最少数目",
+                            "sort": 2,
+                            "src": "/partitioning-into-minimum-number-of-deci-binary-numbers/",
+                            "score": 1355,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "521. 最长特殊序列 Ⅰ",
+                            "sort": 3,
+                            "src": "/longest-uncommon-subsequence-i/",
+                            "score": 1400,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2419. 按位与最大的最长子数组",
+                            "sort": 4,
+                            "src": "/longest-subarray-with-maximum-bitwise-and/",
+                            "score": 1496,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2811. 判断是否能拆分数组",
+                            "sort": 5,
+                            "src": "/check-if-it-is-possible-to-split-array/",
+                            "score": 1543,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2211. 统计道路上的碰撞次数",
+                            "sort": 6,
+                            "src": "/count-collisions-on-a-road/",
+                            "score": 1581,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2546. 执行逐位运算使字符串相等",
+                            "sort": 7,
+                            "src": "/apply-bitwise-operations-to-make-strings-equal/",
+                            "score": 1605,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1503. 所有蚂蚁掉下来前的最后一刻",
+                            "sort": 8,
+                            "src": "/last-moment-before-all-ants-fall-out-of-a-plank/",
+                            "score": 1619,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1975. 最大方阵和",
+                            "sort": 9,
+                            "src": "/maximum-matrix-sum/",
+                            "score": 1648,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1145. 二叉树着色游戏",
+                            "sort": 10,
+                            "src": "/binary-tree-coloring-game/",
+                            "score": 1741,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2680. 最大或值",
+                            "sort": 11,
+                            "src": "/maximum-or/",
+                            "score": 1912,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2731. 移动机器人",
+                            "sort": 12,
+                            "src": "/movement-of-robots/",
+                            "score": 1923,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1794. 统计距离最小的子串对个数",
+                            "sort": 13,
+                            "src": "/count-pairs-of-equal-substrings-with-minimum-difference/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                },
+                {
+                    "title": "§5.3 逆向思维",
+                    "sort": 2,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "2139. 得到目标值的最少行动次数",
+                            "sort": 0,
+                            "src": "/minimum-moves-to-reach-target-score/",
+                            "score": 1417,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1558. 得到目标数组的最少函数调用次数",
+                            "sort": 1,
+                            "src": "/minimum-numbers-of-function-calls-to-make-target-array/",
+                            "score": 1637,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2718. 查询后矩阵的和",
+                            "sort": 2,
+                            "src": "/sum-of-matrix-after-queries/",
+                            "score": 1769,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "417. 太平洋大西洋水流问题",
+                            "sort": 3,
+                            "src": "/pacific-atlantic-water-flow/",
+                            "score": 1900,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "991. 坏了的计算器",
+                            "sort": 4,
+                            "src": "/broken-calculator/",
+                            "score": 1909,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2227. 加密解密字符串",
+                            "sort": 5,
+                            "src": "/encrypt-and-decrypt-strings/",
+                            "score": 1945,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                },
+                {
+                    "title": "§5.4 巧妙转换",
+                    "sort": 3,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "2914. 使二进制字符串变美丽的最少修改次数",
+                            "sort": 0,
+                            "src": "/minimum-number-of-changes-to-make-binary-string-beautiful/",
+                            "score": 1480,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1657. 确定两个字符串是否接近",
+                            "sort": 1,
+                            "src": "/determine-if-two-strings-are-close/",
+                            "score": 1530,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2551. 将珠子放入背包中",
+                            "sort": 2,
+                            "src": "/put-marbles-in-bags/",
+                            "score": 2042,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1585. 检查字符串是否可以通过排序子字符串得到另一个字符串",
+                            "sort": 3,
+                            "src": "/check-if-string-is-transformable-with-substring-sort-operations/",
+                            "score": 2333,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1040. 移动石子直到连续 II",
+                            "sort": 4,
+                            "src": "/moving-stones-until-consecutive-ii/",
+                            "score": 2456,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1183. 矩阵中 1 的最大数量",
+                            "sort": 5,
+                            "src": "/maximum-number-of-ones/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "942. 增减字符串匹配",
+                            "sort": 6,
+                            "src": "/di-string-match/",
+                            "score": 1444,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1968. 构造元素不等于两相邻元素平均值的数组",
+                            "sort": 7,
+                            "src": "/array-with-elements-not-equal-to-average-of-neighbors/",
+                            "score": 1499,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1253. 重构 2 行二进制矩阵",
+                            "sort": 8,
+                            "src": "/reconstruct-a-2-row-binary-matrix/",
+                            "score": 1506,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2182. 构造限制重复的字符串",
+                            "sort": 9,
+                            "src": "/construct-string-with-repeat-limit/",
+                            "score": 1680,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "969. 煎饼排序",
+                            "sort": 10,
+                            "src": "/pancake-sorting/",
+                            "score": 1800,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1605. 给定行和列的和求可行矩阵",
+                            "sort": 11,
+                            "src": "/find-valid-matrix-given-row-and-column-sums/",
+                            "score": 1868,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2375. 根据模式串构造最小数字",
+                            "sort": 12,
+                            "src": "/construct-smallest-number-from-di-string/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "324. 摆动排序 II",
+                            "sort": 13,
+                            "src": "/wiggle-sort-ii/",
+                            "score": 2000,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "667. 优美的排列 II",
+                            "sort": 14,
+                            "src": "/beautiful-arrangement-ii/",
+                            "score": 2100,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2122. 还原原数组",
+                            "sort": 15,
+                            "src": "/recover-the-original-array/",
+                            "score": 2159,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "932. 漂亮数组",
+                            "sort": 16,
+                            "src": "/beautiful-array/",
+                            "score": 2500,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2573. 找出对应 LCP 矩阵的字符串",
+                            "sort": 17,
+                            "src": "/find-the-string-with-lcp/",
+                            "score": 2682,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1982. 从子集的和还原数组",
+                            "sort": 18,
+                            "src": "/find-array-given-subset-sums/",
+                            "score": 2872,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "280. 摆动排序",
+                            "sort": 19,
+                            "src": "/wiggle-sort/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "484. 寻找排列",
+                            "sort": 20,
+                            "src": "/find-permutation/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1033. 移动石子直到连续",
+                            "sort": 21,
+                            "src": "/moving-stones-until-consecutive/",
+                            "score": 1421,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1864. 构成交替字符串需要的最小交换次数",
+                            "sort": 22,
+                            "src": "/minimum-number-of-swaps-to-make-the-binary-string-alternating/",
+                            "score": 1601,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1899. 合并若干三元组以形成目标三元组",
+                            "sort": 23,
+                            "src": "/merge-triplets-to-form-target-triplet/",
+                            "score": 1636,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2498. 青蛙过河 II",
+                            "sort": 24,
+                            "src": "/frog-jump-ii/",
+                            "score": 1759,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2311. 小于等于 K 的最长二进制子序列",
+                            "sort": 25,
+                            "src": "/longest-binary-subsequence-less-than-or-equal-to-k/",
+                            "score": 1840,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3002. 移除后集合的最多元素数",
+                            "sort": 26,
+                            "src": "/maximum-size-of-a-set-after-removals/",
+                            "score": 1917,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "659. 分割数组为连续子序列",
+                            "sort": 27,
+                            "src": "/split-array-into-consecutive-subsequences/",
+                            "score": 2100,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2732. 找到矩阵中的好子集",
+                            "sort": 28,
+                            "src": "/find-a-good-subset-of-the-matrix/",
+                            "score": 2240,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2790. 长度递增组的最大数目",
+                            "sort": 29,
+                            "src": "/maximum-number-of-groups-with-increasing-length/",
+                            "score": 2620,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "782. 变为棋盘",
+                            "sort": 30,
+                            "src": "/transform-to-chessboard/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "420. 强密码检验器",
+                            "sort": 31,
+                            "src": "/strong-password-checker/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCP 26. 导航装置",
+                            "sort": 32,
+                            "src": "/hSRGyL/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCP 70. 沙地治理",
+                            "sort": 33,
+                            "src": "/XxZZjK/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2753. 计算一个环形街道上的房屋数量 II",
+                            "sort": 34,
+                            "src": "/count-houses-in-a-circular-street-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "数学题单",
+                            "sort": 35,
+                            "src": "https://leetcode.cn/circle/discuss/IYT3ss/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "数据结构题单",
+                            "sort": 36,
+                            "src": "https://leetcode.cn/circle/discuss/mOr1u6/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "图论题单",
+                            "sort": 37,
+                            "src": "https://leetcode.cn/circle/discuss/01LUak/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "六、构造题",
+            "sort": 6,
+            "summary": "**构造题**会给定一些约束，我们要构造一个**满足这些约束**的数组/字符串等。<br>思考方式和第五章的「思考清单」是一样的，在特殊情况中寻找灵感。<br>> 如果想做更多思维题和构造题，可以去 Codeforces 看看。<br>",
+            "child": []
+        },
+        {
+            "title": "七、其他",
+            "sort": 7,
+            "summary": "",
+            "child": []
+        },
+        {
+            "title": "答疑",
+            "sort": 8,
+            "summary": "**问**：有没有万能方法，判断一道题是贪心还是 DP？<br>**答**：很难。如果不知道题目类型，把 DP 想成贪心的大有人在。我的建议是**先思考 DP 能不能做，再思考贪心**。<br>此外，这也说明按照题单刷题的缺点：提前知道题目类型，跳过了一些思考步骤。为了弥补这个缺点，也可以按照 <a href=\"https://huxulm.github.io/lc-rating/zen\">难度分</a> 刷题，锻炼自己的「实战能力」。<br>",
+            "child": []
+        }
+    ]
+} as ProblemCategory;

--- a/components/containers/List/data/grid.ts
+++ b/components/containers/List/data/grid.ts
@@ -338,20 +338,6 @@ export default{
                     ]
                 }
             ]
-        },
-        {
-            "title": "思考题",
-            "sort": 3,
-            "summary": "",
-            "child": [
-                {
-                    "title": "",
-                    "sort": 0,
-                    "isLeaf": true,
-                    "summary": "",
-                    "child": []
-                }
-            ]
         }
     ]
 } as ProblemCategory;

--- a/components/containers/List/data/grid.ts
+++ b/components/containers/List/data/grid.ts
@@ -1,0 +1,357 @@
+import ProblemCategory from "@components/ProblemCatetory";
+
+export default{
+    "title": "分享丨【题单】网格图（DFS/BFS/综合应用）",
+    "original_src": "https://leetcode.cn/circle/discuss/YiXPXW",
+    "last_update": "2024-01-30T03:17:53.366314+00:00",
+    "sort": 0,
+    "child": [
+        {
+            "title": "网格图 DFS",
+            "sort": 0,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "部分题目的解法不唯一，也可以用 BFS 或者并查集等算法解决。<br>",
+                    "child": [
+                        {
+                            "title": "200. 岛屿数量",
+                            "sort": 0,
+                            "src": "/number-of-islands/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "695. 岛屿的最大面积",
+                            "sort": 1,
+                            "src": "/max-area-of-island/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "面试题 16.19. 水域大小",
+                            "sort": 2,
+                            "src": "/pond-sizes-lcci/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "463. 岛屿的周长",
+                            "sort": 3,
+                            "src": "/island-perimeter/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2658. 网格图中鱼的最大数目",
+                            "sort": 4,
+                            "src": "/maximum-number-of-fish-in-a-grid/",
+                            "score": 1490,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1034. 边界着色",
+                            "sort": 5,
+                            "src": "/coloring-a-border/",
+                            "score": 1579,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1020. 飞地的数量",
+                            "sort": 6,
+                            "src": "/number-of-enclaves/",
+                            "score": 1615,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1254. 统计封闭岛屿的数目",
+                            "sort": 7,
+                            "src": "/number-of-closed-islands/",
+                            "score": 1659,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "130. 被围绕的区域",
+                            "sort": 8,
+                            "src": "/surrounded-regions/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1391. 检查网格中是否存在有效路径",
+                            "sort": 9,
+                            "src": "/check-if-there-is-a-valid-path-in-a-grid/",
+                            "score": 1746,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "417. 太平洋大西洋水流问题",
+                            "sort": 10,
+                            "src": "/pacific-atlantic-water-flow/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "529. 扫雷游戏",
+                            "sort": 11,
+                            "src": "/minesweeper/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1559. 二维网格图中探测环",
+                            "sort": 12,
+                            "src": "/detect-cycles-in-2d-grid/",
+                            "score": 1838,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "827. 最大人工岛",
+                            "sort": 13,
+                            "src": "/making-a-large-island/",
+                            "score": 1934,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "网格图 BFS",
+            "sort": 1,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "542. 01 矩阵",
+                            "sort": 0,
+                            "src": "/01-matrix/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "994. 腐烂的橘子",
+                            "sort": 1,
+                            "src": "/rotting-oranges/",
+                            "score": 1433,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2684. 矩阵中移动的最大次数",
+                            "sort": 2,
+                            "src": "/maximum-number-of-moves-in-a-grid/",
+                            "score": 1626,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1926. 迷宫中离入口最近的出口",
+                            "sort": 3,
+                            "src": "/nearest-exit-from-entrance-in-maze/",
+                            "score": 1638,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1162. 地图分析",
+                            "sort": 4,
+                            "src": "/as-far-from-land-as-possible/",
+                            "score": 1666,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "934. 最短的桥",
+                            "sort": 5,
+                            "src": "/shortest-bridge/",
+                            "score": 1826,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2146. 价格范围内最高排名的 K 样物品",
+                            "sort": 6,
+                            "src": "/k-highest-ranked-items-within-a-price-range/",
+                            "score": 1837,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1293. 网格中的最短路径",
+                            "sort": 7,
+                            "src": "/shortest-path-in-a-grid-with-obstacles-elimination/",
+                            "score": 1967,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1210. 穿过迷宫的最少移动次数",
+                            "sort": 8,
+                            "src": "/minimum-moves-to-reach-target-with-rotations/",
+                            "score": 2022,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "317. 离建筑物最近的距离",
+                            "sort": 9,
+                            "src": "/shortest-distance-from-all-buildings/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "490. 迷宫",
+                            "sort": 10,
+                            "src": "/the-maze/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "505. 迷宫 II",
+                            "sort": 11,
+                            "src": "/the-maze-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "综合应用",
+            "sort": 2,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "1631. 最小体力消耗路径",
+                            "sort": 0,
+                            "src": "/path-with-minimum-effort/",
+                            "score": 1948,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "778. 水位上升的泳池中游泳",
+                            "sort": 1,
+                            "src": "/swim-in-rising-water/",
+                            "score": 2097,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1036. 逃离大迷宫",
+                            "sort": 2,
+                            "src": "/escape-a-large-maze/",
+                            "score": 2165,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1263. 推箱子",
+                            "sort": 3,
+                            "src": "/minimum-moves-to-move-a-box-to-their-target-location/",
+                            "score": 2297,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2258. 逃离火灾",
+                            "sort": 4,
+                            "src": "/escape-the-spreading-fire/",
+                            "score": 2347,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2577. 在网格图中访问一个格子的最少时间",
+                            "sort": 5,
+                            "src": "/minimum-time-to-visit-a-cell-in-a-grid/",
+                            "score": 2382,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCP 75. 传送卷轴",
+                            "sort": 6,
+                            "src": "/rdmXM7/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCP 13. 寻宝",
+                            "sort": 7,
+                            "src": "/xun-bao/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "LCP 31. 变换的迷宫",
+                            "sort": 8,
+                            "src": "https://leetcode-cn.com/problems/Db3wC1/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1728. 猫和老鼠 II",
+                            "sort": 9,
+                            "src": "/cat-and-mouse-ii/",
+                            "score": 2849,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "思考题",
+            "sort": 3,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": []
+                }
+            ]
+        }
+    ]
+} as ProblemCategory;

--- a/components/containers/List/data/monotonicstack.ts
+++ b/components/containers/List/data/monotonicstack.ts
@@ -1,0 +1,358 @@
+import ProblemCategory from "@components/ProblemCatetory";
+
+export default{
+    "title": "分享｜【题单】单调栈（矩形面积/贡献法/最小字典序）",
+    "original_src": "https://leetcode.cn/circle/discuss/9oZFK9",
+    "last_update": "2024-06-30T23:44:57.532368+00:00",
+    "sort": 0,
+    "child": [
+        {
+            "title": "单调栈",
+            "sort": 0,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "请先学习：<a href=\"https://www.bilibili.com/video/BV1VN411J7S7/\">单调栈【基础算法精讲 26】</a><br>",
+                    "child": [
+                        {
+                            "title": "739. 每日温度",
+                            "sort": 0,
+                            "src": "/daily-temperatures/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1475. 商品折扣后的最终价格",
+                            "sort": 1,
+                            "src": "/final-prices-with-a-special-discount-in-a-shop/",
+                            "score": 1212,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "496. 下一个更大元素 I",
+                            "sort": 2,
+                            "src": "/next-greater-element-i/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "503. 下一个更大元素 II",
+                            "sort": 3,
+                            "src": "/next-greater-element-ii/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1019. 链表中的下一个更大节点",
+                            "sort": 4,
+                            "src": "/next-greater-node-in-linked-list/",
+                            "score": 1571,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "962. 最大宽度坡",
+                            "sort": 5,
+                            "src": "/maximum-width-ramp/",
+                            "score": 1608,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "901. 股票价格跨度",
+                            "sort": 6,
+                            "src": "/online-stock-span/",
+                            "score": 1709,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1124. 表现良好的最长时间段",
+                            "sort": 7,
+                            "src": "/longest-well-performing-interval/",
+                            "score": 1908,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1793. 好子数组的最大分数",
+                            "sort": 8,
+                            "src": "/maximum-score-of-a-good-subarray/",
+                            "score": 1946,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "456. 132 模式",
+                            "sort": 9,
+                            "src": "/132-pattern/",
+                            "score": 2000,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "3113. 边界元素是最大值的子数组数目",
+                            "sort": 10,
+                            "src": "/find-the-number-of-subarrays-where-boundary-elements-are-maximum/",
+                            "score": 2046,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2866. 美丽塔 II",
+                            "sort": 11,
+                            "src": "/beautiful-towers-ii/",
+                            "score": 2072,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1944. 队列中可以看到的人数",
+                            "sort": 12,
+                            "src": "/number-of-visible-people-in-a-queue/",
+                            "score": 2105,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2454. 下一个更大元素 IV",
+                            "sort": 13,
+                            "src": "/next-greater-element-iv/",
+                            "score": 2175,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1130. 叶值的最小代价生成树",
+                            "sort": 14,
+                            "src": "/minimum-cost-tree-from-leaf-values/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2289. 使数组按非递减顺序排列",
+                            "sort": 15,
+                            "src": "/steps-to-make-array-non-decreasing/",
+                            "score": 2482,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1776. 车队 II",
+                            "sort": 16,
+                            "src": "/car-fleet-ii/",
+                            "score": 2531,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1966. 未排序数组中的可被二分搜索的数",
+                            "sort": 17,
+                            "src": "/binary-searchable-numbers-in-an-unsorted-array/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2832. 每个元素为最大值的最大范围",
+                            "sort": 18,
+                            "src": "/maximal-range-that-each-element-is-maximum-in-it/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "矩形面积",
+            "sort": 1,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "42. 接雨水",
+                            "sort": 0,
+                            "src": "/trapping-rain-water/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "84. 柱状图中最大的矩形",
+                            "sort": 1,
+                            "src": "/largest-rectangle-in-histogram/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1793. 好子数组的最大分数",
+                            "sort": 2,
+                            "src": "/maximum-score-of-a-good-subarray/",
+                            "score": 1946,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "85. 最大矩形",
+                            "sort": 3,
+                            "src": "/maximal-rectangle/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1504. 统计全 1 子矩形",
+                            "sort": 4,
+                            "src": "/count-submatrices-with-all-ones/",
+                            "score": 1845,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "贡献法",
+            "sort": 2,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "907. 子数组的最小值之和",
+                            "sort": 0,
+                            "src": "/sum-of-subarray-minimums/",
+                            "score": 1976,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2104. 子数组范围和（最大值-最小值）",
+                            "sort": 1,
+                            "src": "/sum-of-subarray-ranges/",
+                            "score": 2000,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1856. 子数组最小乘积的最大值",
+                            "sort": 2,
+                            "src": "/maximum-subarray-min-product/",
+                            "score": 2051,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2818. 操作使得分最大",
+                            "sort": 3,
+                            "src": "/apply-operations-to-maximize-score/",
+                            "score": 2397,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2281. 巫师的总力量和（最小值×和）",
+                            "sort": 4,
+                            "src": "/sum-of-total-strength-of-wizards/",
+                            "score": 2621,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "最小字典序",
+            "sort": 3,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "402. 移掉 K 位数字",
+                            "sort": 0,
+                            "src": "/remove-k-digits/",
+                            "score": 1800,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1673. 找出最具竞争力的子序列",
+                            "sort": 1,
+                            "src": "/find-the-most-competitive-subsequence/",
+                            "score": 1802,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "316. 去除重复字母",
+                            "sort": 2,
+                            "src": "/remove-duplicate-letters/",
+                            "score": 2185,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "316 扩展：重复个数不超过 limit",
+                            "sort": 3,
+                            "src": "https://leetcode.cn/contest/tianchi2022/problems/ev2bru/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1081. 不同字符的最小子序列",
+                            "sort": 4,
+                            "src": "/smallest-subsequence-of-distinct-characters/",
+                            "score": 316,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "321. 拼接最大数",
+                            "sort": 5,
+                            "src": "/create-maximum-number/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2030. 含特定字母的最小子序列",
+                            "sort": 6,
+                            "src": "/smallest-k-length-subsequence-with-occurrences-of-a-letter/",
+                            "score": 2562,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+} as ProblemCategory;

--- a/components/containers/List/data/slidewindow.ts
+++ b/components/containers/List/data/slidewindow.ts
@@ -1,0 +1,605 @@
+import ProblemCategory from "@components/ProblemCatetory";
+
+export default{
+    "title": "分享丨【题单】滑动窗口（定长/不定长/多指针）",
+    "original_src": "https://leetcode.cn/circle/discuss/0viNMK",
+    "last_update": "2024-01-23T14:12:08.828296+00:00",
+    "sort": 0,
+    "child": [
+        {
+            "title": "定长滑动窗口",
+            "sort": 0,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><br>",
+                    "child": [
+                        {
+                            "title": "1456. 定长子串中元音的最大数目",
+                            "sort": 0,
+                            "src": "/maximum-number-of-vowels-in-a-substring-of-given-length/",
+                            "score": 1263,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2269. 找到一个数字的 K 美丽值",
+                            "sort": 1,
+                            "src": "/find-the-k-beauty-of-a-number/",
+                            "score": 1280,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1984. 学生分数的最小差值",
+                            "sort": 2,
+                            "src": "/minimum-difference-between-highest-and-lowest-of-k-score/",
+                            "score": 1306,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "643. 子数组最大平均数 I",
+                            "sort": 3,
+                            "src": "/maximum-average-subarray-i/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1343. 大小为 K 且平均值大于等于阈值的子数组数目",
+                            "sort": 4,
+                            "src": "/number-of-sub-arrays-of-size-k-and-average-greater-than-or-equal-to-threshold/",
+                            "score": 1317,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2090. 半径为 k 的子数组平均值",
+                            "sort": 5,
+                            "src": "/k-radius-subarray-averages/",
+                            "score": 1358,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2379. 得到 K 个黑块的最少涂色次数",
+                            "sort": 6,
+                            "src": "/minimum-recolors-to-get-k-consecutive-black-blocks/",
+                            "score": 1360,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1052. 爱生气的书店老板",
+                            "sort": 7,
+                            "src": "/grumpy-bookstore-owner/",
+                            "score": 1418,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2841. 几乎唯一子数组的最大和",
+                            "sort": 8,
+                            "src": "/maximum-sum-of-almost-unique-subarray/",
+                            "score": 1546,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2461. 长度为 K 子数组中的最大和",
+                            "sort": 9,
+                            "src": "/maximum-sum-of-distinct-subarrays-with-length-k/",
+                            "score": 1553,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1423. 可获得的最大点数",
+                            "sort": 10,
+                            "src": "/maximum-points-you-can-obtain-from-cards/",
+                            "score": 1574,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2134. 最少交换次数来组合所有的 1 II",
+                            "sort": 11,
+                            "src": "/minimum-swaps-to-group-all-1s-together-ii/",
+                            "score": 1748,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2653. 滑动子数组的美丽值",
+                            "sort": 12,
+                            "src": "/sliding-subarray-beauty/",
+                            "score": 1786,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "567. 字符串的排列",
+                            "sort": 13,
+                            "src": "/permutation-in-string/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "438. 找到字符串中所有字母异位词",
+                            "sort": 14,
+                            "src": "/find-all-anagrams-in-a-string/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2156. 查找给定哈希值的子串",
+                            "sort": 15,
+                            "src": "/find-substring-with-given-hash-value/",
+                            "score": 2063,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2953. 统计完全子字符串",
+                            "sort": 16,
+                            "src": "/count-complete-substrings/",
+                            "score": 2449,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "346. 数据流中的移动平均值",
+                            "sort": 17,
+                            "src": "/moving-average-from-data-stream/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1100. 长度为 K 的无重复字符子串",
+                            "sort": 18,
+                            "src": "/find-k-length-substrings-with-no-repeated-characters/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "1852. 每个子数组的数字种类数",
+                            "sort": 19,
+                            "src": "/distinct-numbers-in-each-subarray/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2067. 等计数子串的数量",
+                            "sort": 20,
+                            "src": "/number-of-equal-count-substrings/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "2107. 分享 K 个糖果后独特口味的数量",
+                            "sort": 21,
+                            "src": "/number-of-unique-flavors-after-sharing-k-candies/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "不定长滑动窗口（求最长/最大）",
+            "sort": 1,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><br>",
+                    "child": [
+                        {
+                            "title": "3. 无重复字符的最长子串",
+                            "sort": 0,
+                            "src": "/longest-substring-without-repeating-characters/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1493. 删掉一个元素以后全为 1 的最长子数组",
+                            "sort": 1,
+                            "src": "/longest-subarray-of-1s-after-deleting-one-element/",
+                            "score": 1423,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2730. 找到最长的半重复子字符串",
+                            "sort": 2,
+                            "src": "/find-the-longest-semi-repetitive-substring/",
+                            "score": 1502,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "904. 水果成篮",
+                            "sort": 3,
+                            "src": "/fruit-into-baskets/",
+                            "score": 1516,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1695. 删除子数组的最大得分",
+                            "sort": 4,
+                            "src": "/maximum-erasure-value/",
+                            "score": 1529,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2958. 最多 K 个重复元素的最长子数组",
+                            "sort": 5,
+                            "src": "/length-of-longest-subarray-with-at-most-k-frequency/",
+                            "score": 1535,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2024. 考试的最大困扰度",
+                            "sort": 6,
+                            "src": "/maximize-the-confusion-of-an-exam/",
+                            "score": 1643,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1004. 最大连续1的个数 III",
+                            "sort": 7,
+                            "src": "/max-consecutive-ones-iii/",
+                            "score": 1656,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1438. 绝对差不超过限制的最长连续子数组",
+                            "sort": 8,
+                            "src": "/longest-continuous-subarray-with-absolute-diff-less-than-or-equal-to-limit/",
+                            "score": 1672,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2401. 最长优雅子数组",
+                            "sort": 9,
+                            "src": "/longest-nice-subarray/",
+                            "score": 1750,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1658. 将 x 减到 0 的最小操作数",
+                            "sort": 10,
+                            "src": "/minimum-operations-to-reduce-x-to-zero/",
+                            "score": 1817,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1838. 最高频元素的频数",
+                            "sort": 11,
+                            "src": "/frequency-of-the-most-frequent-element/",
+                            "score": 1876,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2516. 每种字符至少取 K 个",
+                            "sort": 12,
+                            "src": "/take-k-of-each-character-from-left-and-right/",
+                            "score": 1948,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2831. 找出最长等值子数组",
+                            "sort": 13,
+                            "src": "/find-the-longest-equal-subarray/",
+                            "score": 1976,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2106. 摘水果",
+                            "sort": 14,
+                            "src": "/maximum-fruits-harvested-after-at-most-k-steps/",
+                            "score": 2062,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1610. 可见点的最大数目",
+                            "sort": 15,
+                            "src": "/maximum-number-of-visible-points/",
+                            "score": 2147,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2781. 最长合法子字符串的长度",
+                            "sort": 16,
+                            "src": "/length-of-the-longest-valid-substring/",
+                            "score": 2204,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2968. 执行操作使频率分数最大",
+                            "sort": 17,
+                            "src": "/apply-operations-to-maximize-frequency-score/",
+                            "score": 2444,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "395. 至少有 K 个重复字符的最长子串",
+                            "sort": 18,
+                            "src": "/longest-substring-with-at-least-k-repeating-characters/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1763. 最长的美好子字符串",
+                            "sort": 19,
+                            "src": "/longest-nice-substring/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "159. 至多包含两个不同字符的最长子串",
+                            "sort": 20,
+                            "src": "/longest-substring-with-at-most-two-distinct-characters/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        },
+                        {
+                            "title": "340. 至多包含 K 个不同字符的最长子串",
+                            "sort": 21,
+                            "src": "/longest-substring-with-at-most-k-distinct-characters/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "不定长滑动窗口（求最短/最小）",
+            "sort": 2,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><br>",
+                    "child": [
+                        {
+                            "title": "209. 长度最小的子数组",
+                            "sort": 0,
+                            "src": "/minimum-size-subarray-sum/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1234. 替换子串得到平衡字符串",
+                            "sort": 1,
+                            "src": "/replace-the-substring-for-balanced-string/",
+                            "score": 1878,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1574. 删除最短的子数组使剩余数组有序",
+                            "sort": 2,
+                            "src": "/shortest-subarray-to-be-removed-to-make-array-sorted/",
+                            "score": 1932,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "76. 最小覆盖子串",
+                            "sort": 3,
+                            "src": "/minimum-window-substring/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "面试题 17.18. 最短超串",
+                            "sort": 4,
+                            "src": "/shortest-supersequence-lcci/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "不定长滑动窗口（求子数组个数）",
+            "sort": 3,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "<br><br>",
+                    "child": [
+                        {
+                            "title": "2799. 统计完全子数组的数目",
+                            "sort": 0,
+                            "src": "/count-complete-subarrays-in-an-array/",
+                            "score": 1398,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "713. 乘积小于 K 的子数组",
+                            "sort": 1,
+                            "src": "/subarray-product-less-than-k/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1358. 包含所有三种字符的子字符串数目",
+                            "sort": 2,
+                            "src": "/number-of-substrings-containing-all-three-characters/",
+                            "score": 1646,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2962. 统计最大元素出现至少 K 次的子数组",
+                            "sort": 3,
+                            "src": "/count-subarrays-where-max-element-appears-at-least-k-times/",
+                            "score": 1701,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2302. 统计得分小于 K 的子数组数目",
+                            "sort": 4,
+                            "src": "/count-subarrays-with-score-less-than-k/",
+                            "score": 1808,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2537. 统计好子数组的数目",
+                            "sort": 5,
+                            "src": "/count-the-number-of-good-subarrays/",
+                            "score": 1892,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2762. 不间断子数组",
+                            "sort": 6,
+                            "src": "/continuous-subarrays/",
+                            "score": 1940,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2972. 统计移除递增子数组的数目 II",
+                            "sort": 7,
+                            "src": "/count-the-number-of-incremovable-subarrays-ii/",
+                            "score": 2153,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2743. 计算没有重复字符的子字符串数量",
+                            "sort": 8,
+                            "src": "/count-substrings-without-repeating-character/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "title": "多指针滑动窗口",
+            "sort": 4,
+            "summary": "",
+            "child": [
+                {
+                    "title": "",
+                    "sort": 0,
+                    "isLeaf": true,
+                    "summary": "",
+                    "child": [
+                        {
+                            "title": "930. 和相同的二元子数组",
+                            "sort": 0,
+                            "src": "/binary-subarrays-with-sum/",
+                            "score": 1592,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1248. 统计「优美子数组」",
+                            "sort": 1,
+                            "src": "/count-number-of-nice-subarrays/",
+                            "score": 1624,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2563. 统计公平数对的数目",
+                            "sort": 2,
+                            "src": "/count-the-number-of-fair-pairs/",
+                            "score": 1721,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1712. 将数组分成三个子数组的方案数",
+                            "sort": 3,
+                            "src": "/ways-to-split-array-into-three-subarrays/",
+                            "score": 2079,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "2444. 统计定界子数组的数目",
+                            "sort": 4,
+                            "src": "/count-subarrays-with-fixed-bounds/",
+                            "score": 2093,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "992. K 个不同整数的子数组",
+                            "sort": 5,
+                            "src": "/subarrays-with-k-different-integers/",
+                            "score": 2210,
+                            "solution": null,
+                            "isPremium": false
+                        },
+                        {
+                            "title": "1989. 捉迷藏中可捕获的最大人数",
+                            "sort": 6,
+                            "src": "/maximum-number-of-people-that-can-be-caught-in-tag/",
+                            "score": null,
+                            "solution": null,
+                            "isPremium": true
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+} as ProblemCategory;

--- a/components/containers/List/data/slidewindow.ts
+++ b/components/containers/List/data/slidewindow.ts
@@ -15,7 +15,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><br>",
+                    "summary": "",
                     "child": [
                         {
                             "title": "1456. 定长子串中元音的最大数目",
@@ -36,7 +36,7 @@ export default{
                         {
                             "title": "1984. 学生分数的最小差值",
                             "sort": 2,
-                            "src": "/minimum-difference-between-highest-and-lowest-of-k-score/",
+                            "src": "/minimum-difference-between-highest-and-lowest-of-k-scores/",
                             "score": 1306,
                             "solution": null,
                             "isPremium": false
@@ -206,7 +206,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><br>",
+                    "summary": "",
                     "child": [
                         {
                             "title": "3. 无重复字符的最长子串",
@@ -397,7 +397,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><br>",
+                    "summary": "",
                     "child": [
                         {
                             "title": "209. 长度最小的子数组",
@@ -452,7 +452,7 @@ export default{
                     "title": "",
                     "sort": 0,
                     "isLeaf": true,
-                    "summary": "<br><br>",
+                    "summary": "",
                     "child": [
                         {
                             "title": "2799. 统计完全子数组的数目",

--- a/components/layouts/Navbar/index.tsx
+++ b/components/layouts/Navbar/index.tsx
@@ -52,6 +52,24 @@ export default function () {
             <Link className="nav-link px-lg-3" href="/search">
               <Button className="fw-bold fs-6 p-1">💡0x3F</Button>
             </Link>
+            <Link className="nav-link px-lg-3" href="/list/sw">
+              <Button className="fw-bold fs-6 p-1">📑滑动窗口</Button>
+            </Link>
+            <Link className="nav-link px-lg-3" href="/list/bs">
+              <Button className="fw-bold fs-6 p-1">📑二分查找</Button>
+            </Link>
+            <Link className="nav-link px-lg-3" href="/list/ms">
+              <Button className="fw-bold fs-6 p-1">📑单调栈</Button>
+            </Link>
+            <Link className="nav-link px-lg-3" href="/list/grid">
+              <Button className="fw-bold fs-6 p-1">📑网格图</Button>
+            </Link>
+            <Link className="nav-link px-lg-3" href="/list/bit">
+              <Button className="fw-bold fs-6 p-1">📑位运算</Button>
+            </Link>
+            <Link className="nav-link px-lg-3" href="/list/graph">
+              <Button className="fw-bold fs-6 p-1">📑图论算法</Button>
+            </Link>
             <Link className="nav-link px-lg-3" href="/list/dp">
               <Button className="fw-bold fs-6 p-1">📑动态规划</Button>
             </Link>
@@ -60,6 +78,9 @@ export default function () {
             </Link>
             <Link className="nav-link px-lg-3" href="/list/math">
               <Button className="fw-bold fs-6 p-1">📑数学</Button>
+            </Link>
+            <Link className="nav-link px-lg-3" href="/list/greedy">
+              <Button className="fw-bold fs-6 p-1">📑贪心</Button>
             </Link>
           </Nav>
           <span className="navbar-brand fs-6 fw-semibold">

--- a/lc-maker/0x3f_discuss.py
+++ b/lc-maker/0x3f_discuss.py
@@ -9,14 +9,14 @@ class DiscussionNode:
     title: str
     sort: int
     src: str
-    scores: int
+    score: int
     solution: str
     isPremium: bool
-    def __init__(self, title: str, sort: int, src: str, scores: int, solution: str, isPremium: bool):
+    def __init__(self, title: str, sort: int, src: str, score: int, solution: str, isPremium: bool):
         self.title = title
         self.sort = sort
         self.src = src
-        self.scores = scores
+        self.score = score
         self.solution = solution
         self.isPremium = isPremium
 
@@ -25,7 +25,7 @@ class DiscussionNode:
             "title": self.title,
             "sort": self.sort,
             "src": self.src,
-            "scores": self.scores,
+            "score": self.score,
             "solution": self.solution,
             "isPremium": self.isPremium
         }
@@ -124,11 +124,11 @@ def refactor_discussion_with_sub(content: str):# 有x.x的时候用这个
             markdown_match = re.match(r"\[(.*)\]\((.*)\)", part1)
             title = markdown_match.group(1)
             src = markdown_match.group(2)
-            scores = None
+            score = None
             remain = re.findall(r"\d+", remain_parts)
             if len(remain) > 0:
                 remain = remain[0].strip()
-                scores = int(remain)
+                score = int(remain)
             # 有些题目只有国服有不一定有split_url 前缀
             if split_url in src:
                 src = src.split(split_url)[1]
@@ -141,7 +141,7 @@ def refactor_discussion_with_sub(content: str):# 有x.x的时候用这个
                     solution = second_markdown_match.group(2)
                     if split_url in solution:
                         solution = solution.split(split_url)[1]
-            curr_node = DiscussionNode(title, len(node_list), src, scores, solution, isPremium)
+            curr_node = DiscussionNode(title, len(node_list), src, score, solution, isPremium)
             node_list.append(curr_node)
         else:
             if cont.strip() == "":
@@ -178,11 +178,11 @@ def refactor_discussion(content: str):# 没有x.x的时候用这个
             markdown_match = re.match(r"\[(.*)\]\((.*)\)", part1)
             title = markdown_match.group(1)
             src = markdown_match.group(2)
-            scores = None
+            score = None
             remain = re.findall(r"\d+", remain_parts)
             if len(remain) > 0:
                 remain = remain[0].strip()
-                scores = int(remain)
+                score = int(remain)
             # 有些题目只有国服有不一定有split_url 前缀
             if split_url in src:
                 src = src.split(split_url)[1]
@@ -195,7 +195,7 @@ def refactor_discussion(content: str):# 没有x.x的时候用这个
                     solution = second_markdown_match.group(2)
                     if split_url in solution:
                         solution = solution.split(split_url)[1]
-            curr_node = DiscussionNode(title, len(node_list), src, scores, solution, isPremium)
+            curr_node = DiscussionNode(title, len(node_list), src, score, solution, isPremium)
             node_list.append(curr_node)
         else:
             if cont.strip() == "":
@@ -227,6 +227,6 @@ if __name__ == "__main__":
         "original_src": original_src,
         "last_update": last_update,
         "sort": 0,
-        "child": [child.to_dict() for child in child_list if child.title != "分类题单"]
+        "child": [child.to_dict() for child in child_list if child.title != "分类题单" and child.title != "关联题单"]
     }
     print("import ProblemCategory from \"@components/ProblemCatetory\";\n\nexport default" + json.dumps(parent, indent=4, ensure_ascii=False) + " as ProblemCategory;")

--- a/lc-maker/0x3f_discuss.py
+++ b/lc-maker/0x3f_discuss.py
@@ -1,0 +1,232 @@
+import re
+import json
+import argparse
+from leetcode_api import load_headers, LeetCodeApi
+
+split_url = "https://leetcode.cn/problems"
+
+class DiscussionNode:
+    title: str
+    sort: int
+    src: str
+    scores: int
+    solution: str
+    isPremium: bool
+    def __init__(self, title: str, sort: int, src: str, scores: int, solution: str, isPremium: bool):
+        self.title = title
+        self.sort = sort
+        self.src = src
+        self.scores = scores
+        self.solution = solution
+        self.isPremium = isPremium
+
+    def to_dict(self):
+        return {
+            "title": self.title,
+            "sort": self.sort,
+            "src": self.src,
+            "scores": self.scores,
+            "solution": self.solution,
+            "isPremium": self.isPremium
+        }
+
+class DiscussionLeafNode:
+    title: str
+    sort: int
+    isLeaf: bool
+    summary: str
+    child: list[DiscussionNode]
+
+    def __init__(self, title: str, sort: int, isLeaf: bool, summary: str, child: list[DiscussionNode]):
+        self.title = title
+        self.sort = sort
+        self.isLeaf = isLeaf
+        self.summary = summary
+        self.child = child
+
+    def to_dict(self):
+        return {
+            "title": self.title,
+            "sort": self.sort,
+            "isLeaf": self.isLeaf,
+            "summary": self.summary,
+            "child": [child.to_dict() for child in self.child]
+        }
+    
+class DiscussionSubNode:
+    title: str
+    sort: int
+    summary: str
+    child: list[DiscussionLeafNode]
+
+    def __init__(self, title: str, sort: int, summary: str, child: list[DiscussionLeafNode]):
+        self.title = title
+        self.sort = sort
+        self.summary = summary
+        self.child = child
+
+    def to_dict(self):
+        return {
+            "title": self.title,
+            "sort": self.sort,
+            "summary": self.summary,
+            "child": [child.to_dict() for child in self.child]
+        }
+
+
+def get_discussion(uuid: str, lc: LeetCodeApi):
+    res = lc.qaQuestionDetail(uuid)
+    # we only focus on title, content
+    return (res["qaQuestion"]["title"], res["qaQuestion"]["content"], res["qaQuestion"]["updatedAt"])
+
+def refactor_summary(summary: str):
+    summary = summary.strip()
+    # replace all link to html format
+    pattern = r'\[(.*?)\]\((.*?)\)'
+    repl = r'<a href="\2">\1</a>'
+    return re.sub(pattern, repl, summary)
+
+def refactor_discussion_with_sub(content: str):# 有x.x的时候用这个
+    contents = content.split("\n")
+    # split content in section by "##"
+    sub_node_list = []
+    leaf_node_list = []
+    node_list = []
+    summary = ""
+    for cont in contents:
+        if cont.startswith("###"):
+            summary = refactor_summary(summary)
+            if len(leaf_node_list) > 0:
+                leaf_node_list[-1].summary = summary
+            else:
+                sub_node_list[-1].summary = summary
+            summary = ""
+            title = cont.split("### ")[1]
+            curr_leaf = DiscussionLeafNode(title, len(leaf_node_list), True, "", [])
+            leaf_node_list.append(curr_leaf)
+            node_list = curr_leaf.child
+        elif cont.startswith("##"):
+            summary = refactor_summary(summary)
+            if len(leaf_node_list) > 0:
+                leaf_node_list[-1].summary = summary
+            elif len(sub_node_list) > 0:
+                sub_node_list[-1].summary = summary
+            summary = ""
+            title = cont.split("## ")[1]
+            curr_sub = DiscussionSubNode(title, len(sub_node_list), "", [])
+            sub_node_list.append(curr_sub)
+            leaf_node_list = curr_sub.child
+        elif cont.startswith("- ["):
+            # use regex get []() content
+            pidx = cont.find(")")
+            part1 = cont[2:pidx+1]
+            remain_parts = cont[pidx+2:] # 会员题和题解会在括号之后
+            markdown_match = re.match(r"\[(.*)\]\((.*)\)", part1)
+            title = markdown_match.group(1)
+            src = markdown_match.group(2)
+            scores = None
+            remain = re.findall(r"\d+", remain_parts)
+            if len(remain) > 0:
+                remain = remain[0].strip()
+                scores = int(remain)
+            # 有些题目只有国服有不一定有split_url 前缀
+            if split_url in src:
+                src = src.split(split_url)[1]
+            solution = None
+            isPremium = False
+            if len(remain_parts) > 1:
+                isPremium = "会员题" in remain_parts
+                second_markdown_match = re.match(r"\[(.*)\]\((.*)\)", remain_parts)
+                if second_markdown_match:
+                    solution = second_markdown_match.group(2)
+                    if split_url in solution:
+                        solution = solution.split(split_url)[1]
+            curr_node = DiscussionNode(title, len(node_list), src, scores, solution, isPremium)
+            node_list.append(curr_node)
+        else:
+            if cont.strip() == "":
+                continue
+            summary += cont + "<br>"
+    return sub_node_list
+
+def refactor_discussion(content: str):# 没有x.x的时候用这个
+    contents = content.split("\n")
+    # split content in section by "##"
+    sub_node_list = []
+    leaf_node_list = []
+    node_list = []
+    summary = ""
+    for cont in contents:
+        if cont.startswith("##"):
+            summary = refactor_summary(summary)
+            if len(leaf_node_list) > 0:
+                leaf_node_list[-1].summary = summary
+            summary = ""
+            title = cont.split("## ")[1]
+            sub_node = DiscussionSubNode(title, len(sub_node_list), "", [])
+            leaf_node_list = sub_node.child
+            sub_node_list.append(sub_node)
+            curr_leaf = DiscussionLeafNode("", len(leaf_node_list), True, "", [])
+            leaf_node_list.append(curr_leaf)
+            node_list = curr_leaf.child
+        elif cont.startswith("- ["):
+            # use regex get []() content
+            # find the index of first )
+            pidx = cont.find(")")
+            part1 = cont[2:pidx+1]
+            remain_parts = cont[pidx+2:] # 会员题和题解会在括号之后
+            markdown_match = re.match(r"\[(.*)\]\((.*)\)", part1)
+            title = markdown_match.group(1)
+            src = markdown_match.group(2)
+            scores = None
+            remain = re.findall(r"\d+", remain_parts)
+            if len(remain) > 0:
+                remain = remain[0].strip()
+                scores = int(remain)
+            # 有些题目只有国服有不一定有split_url 前缀
+            if split_url in src:
+                src = src.split(split_url)[1]
+            solution = None
+            isPremium = False
+            if len(remain_parts) > 1:
+                isPremium = "会员题" in remain_parts
+                second_markdown_match = re.match(r"\[(.*)\]\((.*)\)", remain_parts)
+                if second_markdown_match:
+                    solution = second_markdown_match.group(2)
+                    if split_url in solution:
+                        solution = solution.split(split_url)[1]
+            curr_node = DiscussionNode(title, len(node_list), src, scores, solution, isPremium)
+            node_list.append(curr_node)
+        else:
+            if cont.strip() == "":
+                continue
+            summary += cont + "<br>"
+    return sub_node_list
+
+if __name__ == "__main__":
+    hds = load_headers()
+    lc = LeetCodeApi(headers=hds)
+    # read from args
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--uuid", help="uuid of discussion")
+    args = parser.parse_args()
+    if not args.uuid:
+        print("usage: python 0x3f_discuss.py --uuid <uuid>")
+        exit(1)
+    uuid = args.uuid
+    title, content, last_update = get_discussion(uuid, lc)
+    content = content.replace("\r\n", "\n")
+    original_src = "https://leetcode.cn/circle/discuss/" + uuid
+    child_list = None
+    if re.search(r'\n## [^\n]*\n', content) and re.search(r'\n### [^\n]*\n', content): # 有二级标题和三级标题
+        child_list = refactor_discussion_with_sub(content)
+    else:
+        child_list = refactor_discussion(content)
+    parent = {
+        "title": title,
+        "original_src": original_src,
+        "last_update": last_update,
+        "sort": 0,
+        "child": [child.to_dict() for child in child_list if child.title != "分类题单"]
+    }
+    print("import ProblemCategory from \"@components/ProblemCatetory\";\n\nexport default" + json.dumps(parent, indent=4, ensure_ascii=False) + " as ProblemCategory;")

--- a/lc-maker/README.md
+++ b/lc-maker/README.md
@@ -2,3 +2,9 @@
 1. 从力扣页面 复制Cookie 替换 hds.txt 中的 Cookie 值
 2. 安装依赖：pip install -r requirements.txt (如抛出异常 "No module named 'pip'", 可先执行 python -m ensurepip)
 3. 执行：python main.py
+
+## 使用灵茶山艾府的题单生成对应网页
+1. 安装依赖：pip install -r requirements.txt (如抛出异常 "No module named 'pip'", 可先执行 python -m ensurepip)
+2. 执行：python 0x3f_discuss.py xxxx > somename.ts
+   - 此处xxxx为尾uuid, 例如对于讨论页面https://leetcode.cn/circle/discuss/dHn9Vk/，dHn9Vk是这个讨论页面的uuid
+3. 将这个ts文件放进`components/containers/List/data`中, 并在`components/containers/List/`下创建对应的文件夹以及`index.tsx`文件, 并在`app/(lc)/list`下创建对应的文件以启用

--- a/lc-maker/leetcode_api.py
+++ b/lc-maker/leetcode_api.py
@@ -61,6 +61,7 @@ class LeetCodeApi:
         variables = {"limit": "100", "skip": "0"}
         op = "favoriteMyFavorites"
         return self.client.execute(query, variable_values=variables, operation_name=op)
+    
     def getMyFav_0(self):
         query = gql("\n    query myFavoriteList {\n  myCreatedFavoriteList {\n    favorites {\n      coverUrl\n      coverEmoji\n      coverBackgroundColor\n      hasCurrentQuestion\n      isPublicFavorite\n      lastQuestionAddedAt\n      name\n      slug\n    }\n    hasMore\n    totalLength\n  }\n  myCollectedFavoriteList {\n    hasMore\n    totalLength\n    favorites {\n      coverUrl\n      coverEmoji\n      coverBackgroundColor\n      hasCurrentQuestion\n      isPublicFavorite\n      name\n      slug\n      lastQuestionAddedAt\n    }\n  }\n}\n    ")
         return self.client.execute(query, variable_values={}, operation_name="myFavoriteList")
@@ -124,3 +125,7 @@ class LeetCodeApi:
             }
     """)
         return self.client.execute(query, variable_values={"titleSlug": titleSlug}, operation_name="questionTitle")
+    
+    def qaQuestionDetail(self, uuid):
+        query = gql("""query qaQuestionDetail($uuid: ID!) {\n  qaQuestion(uuid: $uuid) {\n    ...qaQuestion\n    myAnswerId\n    __typename\n  }\n}\n\nfragment qaQuestion on QAQuestionNode {\n  ipRegion\n  uuid\n  slug\n  title\n  thumbnail\n  summary\n  content\n  slateValue\n  sunk\n  pinned\n  pinnedGlobally\n  byLeetcode\n  isRecommended\n  isRecommendedGlobally\n  subscribed\n  hitCount\n  numAnswers\n  numPeopleInvolved\n  numSubscribed\n  createdAt\n  updatedAt\n  status\n  identifier\n  resourceType\n  articleType\n  alwaysShow\n  alwaysExpand\n  score\n  favoriteCount\n  isMyFavorite\n  isAnonymous\n  canEdit\n  reactionType\n  atQuestionTitleSlug\n  blockComments\n  reactionsV2 {\n    count\n    reactionType\n    __typename\n  }\n  tags {\n    name\n    nameTranslated\n    slug\n    imgUrl\n    tagType\n    __typename\n  }\n  subject {\n    slug\n    title\n    __typename\n  }\n  contentAuthor {\n    ...contentAuthor\n    __typename\n  }\n  realAuthor {\n    ...realAuthor\n    __typename\n  }\n  __typename\n}\n\nfragment contentAuthor on ArticleAuthor {\n  username\n  userSlug\n  realName\n  avatar\n  __typename\n}\n\nfragment realAuthor on UserNode {\n  username\n  profile {\n    userSlug\n    realName\n    userAvatar\n    __typename\n  }\n  __typename\n}\n""")
+        return self.client.execute(query, variable_values={"uuid": uuid}, operation_name="qaQuestionDetail")


### PR DESCRIPTION
可以[预览](https://yorafa.github.io/lc-rating/)看一下从我的fork部署的

具体新增了:
- 滑动窗口（定长/不定长/多指针）
- 二分算法（二分答案/最小化最大值/最大化最小值/第K小）
- 单调栈（基础/矩形面积/贡献法/最小字典序）
- 网格图（DFS/BFS/综合应用）
- 位运算（基础/性质/拆位/试填/恒等式/贪心/脑筋急转弯）
- 图论算法（DFS/BFS/拓扑排序/最短路/最小生成树/二分图/基环树/欧拉路径）
- 贪心算法（基本贪心策略/反悔/区间/字典序/数学/思维/脑筋急转弯/构造）
- python script用于调取leetcode讨论中的内容并加以处理，处理时加入了isPremium属性以备用 (仅限题单中题目)
  - 分数基于提取题目后的数字可能不准