### PR TITLE
网站崩溃紧急修复

### DIFF
--- a/components/SettingsPanel/settingPages/CustomizeOptions/Preview.tsx
+++ b/components/SettingsPanel/settingPages/CustomizeOptions/Preview.tsx
@@ -10,9 +10,9 @@ function Preview({ options }: PreviewProps) {
   return (
     <div className="p-3 border rounded">
       <FormLabel className="fw-bold">预览</FormLabel>
-      {options.map((option) => (
+      {options.map((option, i) => (
         <Form.Select
-          key={option.key}
+          key={i}
           defaultValue={option.key}
           style={{ color: option.color }}
           className="my-1"

--- a/hooks/useStorage.ts
+++ b/hooks/useStorage.ts
@@ -57,7 +57,10 @@ class StorageStore<T> {
   private getValue(): T | undefined {
     const storage = this.getStorage();
     const value = storage?.getItem(this.key);
-    if (value !== undefined && value !== null) {
+    if (value === undefined || value === null) {
+      return this.options.defaultValue;
+    }
+    try {
       const decryptedValue =
         "decrypt" in this.options ? this.options.decrypt(value) : value;
       const deserializedValue =
@@ -65,8 +68,10 @@ class StorageStore<T> {
           ? this.options.deserializer(decryptedValue)
           : JSON.parse(decryptedValue);
       return deserializedValue;
+    } catch (error) {
+      console.error("Failed to parse value from storage: ", error);
+      return this.options.defaultValue;
     }
-    return this.options.defaultValue;
   }
 
   private setValue(value: T | undefined) {


### PR DESCRIPTION
fix:
1. 修复useStorage解析异常导致网站崩溃的bug。原因是之前useTheme自己存取LocalStorage时，没有对字符串进行序列化，localStorage存的是 "light" 或 "dark"。新版本useStorage控制的localStorage存取的是"'light'"或"'dark'"。如果是旧版本存的theme值被新版本解析，JSON.parse会产生异常。
2. 修复预览循环渲染key重复的问题。